### PR TITLE
WIP: dasher integration

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -201,6 +201,47 @@ kbd_press_key(struct kbd *kb, struct key *k, uint32_t time) {
 	}
 
 	switch (k->type) {
+	case StringFn:
+		const char *s = (*k->string_fn)();
+		for (const char *c = s; *c != 0; c++) {
+			// Find the key code for this character.
+			uint32_t code;
+			bool shift;
+			for (int il = 0; il < NumLayouts; il++) {
+				struct key *key = layouts[il].keys;
+				if (!key) {
+					continue;
+				}
+				for (; key->type != Last; key++) {
+					if (key->type != Code) {
+						continue;
+					}
+					if (key->label && (*key->label == *c)) {
+						code = key->code;
+						shift = 0;
+						goto found_code;
+					}
+					if (key->shift_label && (*key->shift_label == *c)) {
+						code = key->code;
+						shift = 1;
+						goto found_code;
+					}
+				}
+			}
+			// Reaching here means key code not found.
+			continue;
+		found_code:
+			if (shift) {
+				zwp_virtual_keyboard_v1_modifiers(kb->vkbd, Shift, 0, 0, 0);
+			}
+			zwp_virtual_keyboard_v1_key(kb->vkbd, time, code,
+						    WL_KEYBOARD_KEY_STATE_PRESSED);
+			zwp_virtual_keyboard_v1_key(kb->vkbd, time, code,
+			                            WL_KEYBOARD_KEY_STATE_RELEASED);
+			if (shift) {
+				zwp_virtual_keyboard_v1_modifiers(kb->vkbd, 0, 0, 0, 0);
+			}
+		}
 	case Code:
 		if (k->code_mod) {
 			if (k->reset_mod) {

--- a/keyboard.h
+++ b/keyboard.h
@@ -26,6 +26,7 @@ enum key_type {
 	           // upon next keypress
 	EndRow,    // Incidates the end of a key row
 	Last,      // Indicated the end of a layout
+	StringFn,  // Function that somehow obtains a string to input
 };
 
 /* Modifiers passed to the virtual_keyboard protocol. They are based on
@@ -68,6 +69,8 @@ struct key {
 	// actual coordinates on the surface (pixels), will be computed automatically
 	// for all keys
 	uint32_t x, y, w, h;
+
+	const char *(*string_fn)();
 };
 
 struct layout {

--- a/layout.mobintl.h
+++ b/layout.mobintl.h
@@ -131,6 +131,10 @@ static struct layout layouts[NumLayouts] = {
   [ComposeCyrK] = {keys_compose_cyr_k, "cyrillic"},
 };
 
+static const char *njnj() {
+	return "njnj";
+}
+
 /* key layouts
  *
  * define keys like:
@@ -227,6 +231,7 @@ static struct key keys_full[] = {
   {"Alt", "Alt", 1.0, Mod, Alt, .scheme = 1},
   {",", "'", 1.0, Code, KEY_COMMA},
   {"", "", 4.0, Code, KEY_SPACE},
+  {"njnj", "", 4.0, StringFn, .string_fn = njnj},
   {".", "?", 1.0, Code, KEY_DOT},
   {"Enter", "Enter", 2.0, Code, KEY_ENTER, .scheme = 1},
 

--- a/layout.mobintl.h
+++ b/layout.mobintl.h
@@ -131,8 +131,17 @@ static struct layout layouts[NumLayouts] = {
   [ComposeCyrK] = {keys_compose_cyr_k, "cyrillic"},
 };
 
-static const char *njnj() {
-	return "njnj";
+static const char *dasher() {
+	FILE *fp = popen("/usr/bin/dasher-get-input", "r");
+	char buf[1024];
+	const char *input = "";
+	if (fp) {
+		if (fgets(buf, sizeof(buf), fp) != NULL) {
+			input = buf;
+		}
+		pclose(fp);
+	}
+	return input;
 }
 
 /* key layouts
@@ -231,7 +240,7 @@ static struct key keys_full[] = {
   {"Alt", "Alt", 1.0, Mod, Alt, .scheme = 1},
   {",", "'", 1.0, Code, KEY_COMMA},
   {"", "", 4.0, Code, KEY_SPACE},
-  {"njnj", "", 4.0, StringFn, .string_fn = njnj},
+  {"njnj", "", 4.0, StringFn, .string_fn = dasher},
   {".", "?", 1.0, Code, KEY_DOT},
   {"Enter", "Enter", 2.0, Code, KEY_ENTER, .scheme = 1},
 


### PR DESCRIPTION
Dasher is a method of text entry that works by moving a cursor over a field of possible next letters that appear from the right hand edge of Dasher's window and move to the left.  It incorporates language-dependent probabilities so that it's easier to select the more likely next letters, but it also remains possible to select _any_ sequence of next letters.

I believe it's used quite widely by people who can't use normal keyboards, and there are various approaches to controlling the cursor position, including buttons, eye tracking and tilt.

In the context of Linux phones, I'm interested in the tilt approach, with

- left / right tilt controlling how quickly the cursor moves to the right (or, more correctly, the possible next letters move to the left)
- down / up tilt controlling which of the possible next letters is selected.

Please see also the Dasher home page at https://www.inference.org.uk/dasher/