### PR TITLE
Swipe output

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ Wvkbd has an output mode `-o` that will echo its output to standard output. This
 audio/haptic feedback, a feature explicitly out of scope for wvkbd. To achieve this, simply pipe wvkbd's output through the external tool
 [clickclack](https://git.sr.ht/~proycon/clickclack):
 
-`$ wvkbd-mobileintl -l simple,special,emoji -o | clickclack -V -f keypress.wav`
+`$ wvkbd-mobintl -l simple,special,emoji -o | clickclack -V -f keypress.wav`
+
+Another output mode, `-O` will let the keyboard output keys which are swiped over. It can be used by an external program, such as [swipeGuess](https://git.sr.ht/~earboxer/swipeGuess) to get swipe-typing support.
+
+`$ wvkbd-mobintl -O | swipeGuess.sh words.txt | completelyTypeWord.sh`
+
 
 ## Contribute
 
@@ -80,6 +85,7 @@ possible.
 ## Related projects
 
 * [clickclack](https://git.sr.ht/~proycon/clickclack) - Audio/haptic feedback (standalone)
+* [swipeGuess](https://git.sr.ht/~earboxer/swipeGuess) - Word-completion for swipe-typing
 * [Sxmo](https://sxmo.org) - A hackable mobile interface environment for Linux phones that adopted wvkbd as its keyboard
 * [svkbd](https://tools.suckless.org/x/svkbd/) - A similar project as wvkbd but for X11 rather than Wayland
 * [squeekboard](https://gitlab.gnome.org/World/Phosh/squeekboard) - The virtual keyboard developed for the Librem5 (used

--- a/config.def.h
+++ b/config.def.h
@@ -8,6 +8,7 @@ struct clr_scheme scheme = {
   .bg = {.bgra = {15, 15, 15, 225}},
   .fg = {.bgra = {45, 45, 45, 225}},
   .high = {.bgra = {100, 100, 100, 225}},
+  .swipe = {.bgra = {100, 255, 100, 64}},
   .text = {.color = UINT32_MAX},
 };
 struct clr_scheme scheme1 = {
@@ -15,6 +16,7 @@ struct clr_scheme scheme1 = {
   .bg = {.bgra = {15, 15, 15, 225}},
   .fg = {.bgra = {32, 32, 32, 225}},
   .high = {.bgra = {100, 100, 100, 225}},
+  .swipe = {.bgra = {100, 255, 100, 64}},
   .text = {.color = UINT32_MAX},
 };
 

--- a/drw.c
+++ b/drw.c
@@ -69,11 +69,15 @@ drw_draw_text(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
 }
 
 void
-drw_fill_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
-                   uint32_t w, uint32_t h) {
+drw_do_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
+                 uint32_t w, uint32_t h, bool over) {
 	cairo_save(d->cairo);
 
-	cairo_set_operator(d->cairo, CAIRO_OPERATOR_SOURCE);
+	if (over) {
+		cairo_set_operator(d->cairo, CAIRO_OPERATOR_OVER);
+	} else {
+		cairo_set_operator(d->cairo, CAIRO_OPERATOR_SOURCE);
+	}
 
 	cairo_rectangle(d->cairo, x, y, w, h);
 	cairo_set_source_rgba(
@@ -81,9 +85,22 @@ drw_fill_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
 	  color.bgra[0] / (double)255, color.bgra[3] / (double)255);
 	cairo_fill(d->cairo);
 
+
 	cairo_restore(d->cairo);
 
 	wl_surface_damage(d->surf, x, y, w, h);
+}
+
+void
+drw_fill_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
+                   uint32_t w, uint32_t h) {
+	drw_do_rectangle(d, color, x, y, w, h, false);
+}
+
+void
+drw_over_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
+                   uint32_t w, uint32_t h) {
+	drw_do_rectangle(d, color, x, y, w, h, true);
 }
 
 uint32_t

--- a/drw.h
+++ b/drw.h
@@ -31,7 +31,11 @@ typedef union {
 	uint32_t color;
 } Color;
 
+void drw_do_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
+                      uint32_t w, uint32_t h, bool fill);
 void drw_fill_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
+                        uint32_t w, uint32_t h);
+void drw_over_rectangle(struct drwsurf *d, Color color, uint32_t x, uint32_t y,
                         uint32_t w, uint32_t h);
 
 void drw_draw_text(struct drwsurf *d, Color color, uint32_t x, uint32_t y,

--- a/keyboard.h
+++ b/keyboard.h
@@ -45,6 +45,7 @@ struct clr_scheme {
 	Color fg;
 	Color bg;
 	Color high;
+	Color swipe;
 	Color text;
 };
 
@@ -105,6 +106,8 @@ struct kbd {
 
 void draw_inset(struct drwsurf *ds, uint32_t x, uint32_t y, uint32_t width,
                 uint32_t height, uint32_t border, Color color);
+void draw_over_inset(struct drwsurf *ds, uint32_t x, uint32_t y, uint32_t width,
+                     uint32_t height, uint32_t border, Color color);
 
 void kbd_init(struct kbd *kb, struct layout *layouts, char *layer_names_list);
 void kbd_init_layout(struct layout *l, uint32_t width, uint32_t height);
@@ -114,7 +117,9 @@ void kbd_release_key(struct kbd *kb, uint32_t time);
 void kbd_motion_key(struct kbd *kb, uint32_t time, uint32_t x, uint32_t y);
 void kbd_press_key(struct kbd *kb, struct key *k, uint32_t time);
 void kbd_print_key_stdout(struct kbd *kb, struct key *k);
-void kbd_draw_key(struct kbd *kb, struct key *k, bool pressed);
+void kbd_draw_key(struct kbd *kb, struct key *k, bool pressed, bool swiped);
+void kbd_draw_press(struct kbd *kb, struct key *k, bool pressed);
+void kbd_draw_swipe(struct kbd *kb, struct key *k);
 void kbd_draw_layout(struct kbd *kb);
 void kbd_resize(struct kbd *kb, struct layout *layouts, uint8_t layoutcount);
 uint8_t kbd_get_rows(struct layout *l);

--- a/keyboard.h
+++ b/keyboard.h
@@ -85,11 +85,13 @@ struct kbd {
 	struct clr_scheme scheme1;
 
 	bool print;
+	bool print_intersect;
 	uint32_t w, h, s;
 	bool landscape;
 	uint8_t mods;
 	uint8_t compose;
 	struct key *last_press;
+	struct key *last_swipe;
 	struct layout *prevlayout;
 	size_t layer_index;
 
@@ -108,6 +110,8 @@ void kbd_init(struct kbd *kb, struct layout *layouts, char *layer_names_list);
 void kbd_init_layout(struct layout *l, uint32_t width, uint32_t height);
 struct key *kbd_get_key(struct kbd *kb, uint32_t x, uint32_t y);
 void kbd_unpress_key(struct kbd *kb, uint32_t time);
+void kbd_release_key(struct kbd *kb, uint32_t time);
+void kbd_motion_key(struct kbd *kb, uint32_t time, uint32_t x, uint32_t y);
 void kbd_press_key(struct kbd *kb, struct key *k, uint32_t time);
 void kbd_print_key_stdout(struct kbd *kb, struct key *k);
 void kbd_draw_key(struct kbd *kb, struct key *k, bool pressed);

--- a/keyboard.h
+++ b/keyboard.h
@@ -41,6 +41,12 @@ enum key_modifier_type {
 	AltGr = 128,
 };
 
+enum key_draw_type {
+	Unpress = 0,
+	Press,
+	Swipe,
+};
+
 struct clr_scheme {
 	Color fg;
 	Color bg;
@@ -117,9 +123,7 @@ void kbd_release_key(struct kbd *kb, uint32_t time);
 void kbd_motion_key(struct kbd *kb, uint32_t time, uint32_t x, uint32_t y);
 void kbd_press_key(struct kbd *kb, struct key *k, uint32_t time);
 void kbd_print_key_stdout(struct kbd *kb, struct key *k);
-void kbd_draw_key(struct kbd *kb, struct key *k, bool pressed, bool swiped);
-void kbd_draw_press(struct kbd *kb, struct key *k, bool pressed);
-void kbd_draw_swipe(struct kbd *kb, struct key *k);
+void kbd_draw_key(struct kbd *kb, struct key *k, enum key_draw_type);
 void kbd_draw_layout(struct kbd *kb);
 void kbd_resize(struct kbd *kb, struct layout *layouts, uint8_t layoutcount);
 uint8_t kbd_get_rows(struct layout *l);


### PR DESCRIPTION
(as seen in in https://lists.sr.ht/~mil/sxmo-devel/patches/27037 and https://lists.sr.ht/~mil/sxmo-devel/patches/27086)

> From the first revision of the patch, this adds
> * Mouse-support (thanks to the refactoring staceee requested)
> * Configurable highlighting that gets brighter on subsequent overlaps
> * Fix output of the first letter when you swipe too fast.
> 
> Known "issues" (which I think are non-issues)
> which affect usage with swipeGuess | completelyTypeWord:
> 
> * If you swipe from the blank space to the right of the "l"
> (and spell out a word, like "like"), it will type "ike",
> because it doesn't know the "l" hasn't been typed.
> 
> * If you swipe with multiple fingers at the same time,
> such as left thumb "a", right thumb "pl", left thumb "e", it will type "pple",
> resulting in "appple" being typed (note the extra "p"),
> (unless you started your right thumb from the blank space to the right of "l").
> 
> I'm not sure there's a good solution to these.
> The current implementation keeps wvkbd's typing behavior unchanged.



As seen in https://social.librem.one/@zachdecook/107384429641135497 (older version at https://social.librem.one/@zachdecook/107374196848237821)
