### PR TITLE
shift key: unshift when indicated

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -182,8 +182,10 @@ kbd_unpress_key(struct kbd *kb, uint32_t time) {
 			kbd_switch_layout(kb, kb->prevlayout);
 			if ((kb->mods & Shift) == Shift)
 				kb->mods ^= Shift;
+				zwp_virtual_keyboard_v1_modifiers(kb->vkbd, kb->mods, 0, 0, 0);
 		} else if ((kb->mods & Shift) == Shift) {
 			kb->mods ^= Shift;
+			zwp_virtual_keyboard_v1_modifiers(kb->vkbd, kb->mods, 0, 0, 0);
 			kbd_draw_layout(kb);
 		}
 	}


### PR DESCRIPTION
The big use-case for this is when using a program in which shift+click has a special meaning.

Without this fix, the shift key would remain held until another key was sent on the keyboard.