### PR TITLE
main: prevent crash on sigpipe

### DIFF
--- a/main.c
+++ b/main.c
@@ -398,6 +398,11 @@ show(int sigint) {
 	drwsurf_flip(&draw_surf);
 }
 
+void
+pipewarn(int sigint) {
+	fprintf(stderr, "wvkbd: cannot pipe data out.\n");
+}
+
 int
 main(int argc, char **argv) {
 	/* parse command line arguments */
@@ -530,6 +535,7 @@ main(int argc, char **argv) {
 
 	signal(SIGUSR1, hide);
 	signal(SIGUSR2, show);
+	signal(SIGPIPE, pipewarn);
 
 	while (run_display) {
 		while (wl_display_dispatch(display) != -1 && layer_surface) {


### PR DESCRIPTION
This is commonly caused by a bad program in the output chain, e.g.

wvkbd -O | false

It's triggered whenever output is flushed to a broken pipe (log files will easily be able to tell that something is critically wrong).

I find this very helpful for developing [SwipeBehaviors](https://git.sr.ht/~earboxer/SwipeBehaviors). A little syntax error in a script and **bam**, my device was no longer usable (without SSH-ing from another device and fixing the syntax error).