### PR TITLE
fix seat_handle_capabilities

### DIFF
--- a/main.c
+++ b/main.c
@@ -277,6 +277,7 @@ seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	} else {
 		if (pointer != NULL) {
 			wl_pointer_destroy(pointer);
+			pointer = NULL;
 		}
 	}
 	if ((caps & WL_SEAT_CAPABILITY_TOUCH)) {
@@ -287,6 +288,7 @@ seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	} else {
 		if (touch != NULL) {
 			wl_touch_destroy(touch);
+			touch = NULL;
 		}
 	}
 }

--- a/main.c
+++ b/main.c
@@ -270,12 +270,24 @@ void
 seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
                          enum wl_seat_capability caps) {
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
-		pointer = wl_seat_get_pointer(wl_seat);
-		wl_pointer_add_listener(pointer, &pointer_listener, NULL);
+		if (pointer == NULL) {
+			pointer = wl_seat_get_pointer(wl_seat);
+			wl_pointer_add_listener(pointer, &pointer_listener, NULL);
+		}
+	} else {
+		if (pointer != NULL) {
+			wl_pointer_destroy(pointer);
+		}
 	}
 	if ((caps & WL_SEAT_CAPABILITY_TOUCH)) {
-		touch = wl_seat_get_touch(wl_seat);
-		wl_touch_add_listener(touch, &touch_listener, NULL);
+		if (touch == NULL) {
+			touch = wl_seat_get_touch(wl_seat);
+			wl_touch_add_listener(touch, &touch_listener, NULL);
+		}
+	} else {
+		if (touch != NULL) {
+			wl_touch_destroy(touch);
+		}
 	}
 }
 


### PR DESCRIPTION
seat_handle_capabilities may be called more than once with different caps.
In the current implementation, wl_{pointer,touch}_add_listener can be called multiple times for the same seat, causing the buttons to be pressed more than once in a single tap.
This commit implements seat_handle_capabilities correctly and avoids setting duplicate handlers, and also handles the removal of capabilities.

Tested on sway-1.8.1
Also solves #36