### PR TITLE
Fix crash on newer sway

### DIFF
--- a/main.c
+++ b/main.c
@@ -354,10 +354,6 @@ wl_surface_enter(void *data, struct wl_surface *wl_surface,
     }
 
     keyboard.preferred_scale = current_output->scale;
-
-    flip_landscape();
-    kbd_resize(&keyboard, layouts, NumLayouts);
-    drwsurf_flip(&draw_surf);
 }
 
 static void


### PR DESCRIPTION
fix #50
tested on sway-1.8.1, sway-HEAD(020a572), Hyprland-HEAD(200cccd)

After https://github.com/swaywm/sway/commit/7d2e4a51063a, sway sends surface_enter event before any configure events.
Let's adopt to this.
