### PR TITLE
Fixed malfunctioning theme at random (#59)

### DIFF
--- a/main.c
+++ b/main.c
@@ -797,7 +797,7 @@ set_kbd_colors(uint8_t *bgra, char *hex)
     // bg, fg, text, high, swipe
     int length = strlen(hex);
     if (length == 6 || length == 8) {
-        char subhex[2];
+        char subhex[3] = { 0 };
         memcpy(subhex, hex, 2);
         bgra[2] = (int)strtol(subhex, NULL, 16);
         memcpy(subhex, hex + 2, 2);


### PR DESCRIPTION
I realized that the theme only gets messed up if you use command line arguments.
Didn't take too long for me to find the `set_kbd_colors` function, which does the parsing of the hex of the command line.
It uses the `strtol` function to read the bytes, which stops at the first non-parsable character.
Without the fix, the `subhex` is only 2 bytes long to fit the characters, but doesn't have an extra byte for the null terminator.
This PR fixes that by adding an extra byte to the `subhex` buffer, and initializing it to `{ 0 }` so that all bytes are zeroed.

Fixes #59 

On a side note, I think nobody else noticed because usually in systems with glibc, the stack is usually filled with zeroes and avoids issues like this in the first place from happening in runtime. Also due to the fact that I think a lot of people didn't mess with the theme in the command line.