### PR TITLE
Add deskintl (desktop international) layout set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ wvkbd
 *.1
 config.h
 wvkbd-mobintl
+wvkbd-deskintl

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ OBJECTS = $(SOURCES:.c=.o)
 all: ${BIN} ${DOCS}
 
 config.h:
-	cp config.def.h config.h
+	cp config.${LAYOUT}.h config.h
 
 proto/%-client-protocol.c: proto/%.xml
 	wayland-scanner code < $? > $@
@@ -43,7 +43,7 @@ wvkbd-${LAYOUT}: config.h $(OBJECTS) layout.${LAYOUT}.h
 	$(CC) -o wvkbd-${LAYOUT} $(OBJECTS) $(LDFLAGS)
 
 clean:
-	rm -f $(OBJECTS) $(HDRS) $(WAYLAND_SRC) ${BIN} ${DOCS}
+	rm -f $(OBJECTS) config.h $(HDRS) $(WAYLAND_SRC) ${BIN} ${DOCS}
 
 format:
 	clang-format -i $(WVKBD_SOURCES) $(WVKBD_HEADERS)

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ Make any customizations you would like in `config.def.h` and run `make`
 The default set of layouts is called `mobintl` *(mobile international)*, which groups various layouts aimed at mobile devices
 and also attempts to accommodate various international users. The resulting binary is called `wvkbd-mobintl`.
 
+The other set of layouts is called `deskintl` *(desktop international)*, which groups layouts aimed at desktop, laptop, and
+tablet devices with a larger touchscreen. The set is US-International English. Run `make LAYOUT=deskintl`. The resulting binary
+is called `wvkbd-deskintl`.
+
 You can, however, define your own layouts by copying and modifying `layout.mobintl.h` and `keymap.mobintl.h`
-(replace `mobintl` for something like `yourlayout`). Then make your layout set using `make LAYOUT=yourlayout`, and
-the resulting binary will be `wvkbd-yourlayout`
+(replace `mobintl` for something like `yourlayout`), or `layout.deskintl.h` and `keymap.deskintl.h`. Then make your layout set
+using `make LAYOUT=yourlayout`, and the resulting binary will be `wvkbd-yourlayout`.
 
 ## Usage
 

--- a/config.deskintl.h
+++ b/config.deskintl.h
@@ -1,0 +1,45 @@
+#ifndef config_h_INCLUDED
+#define config_h_INCLUDED
+
+#define DEFAULT_FONT "Sans 14"
+#define DEFAULT_ROUNDING 5
+static const int transparency = 255;
+
+struct clr_scheme schemes[] = {
+{
+  /* colors */
+  .bg = {.bgra = {15, 15, 15, transparency}},
+  .fg = {.bgra = {45, 45, 45, transparency}},
+  .high = {.bgra = {100, 100, 100, transparency}},
+  .swipe = {.bgra = {100, 255, 100, 64}},
+  .text = {.color = UINT32_MAX},
+  .font = DEFAULT_FONT,
+  .rounding = DEFAULT_ROUNDING,
+},
+{
+  /* colors */
+  .bg = {.bgra = {15, 15, 15, transparency}},
+  .fg = {.bgra = {32, 32, 32, transparency}},
+  .high = {.bgra = {100, 100, 100, transparency}},
+  .swipe = {.bgra = {100, 255, 100, 64}},
+  .text = {.color = UINT32_MAX},
+  .font = DEFAULT_FONT,
+  .rounding = DEFAULT_ROUNDING,
+}
+};
+
+/* layers is an ordered list of layouts, used to cycle through */
+static enum layout_id layers[] = {
+  Full, // First layout is the default layout on startup
+  Special,
+  NumLayouts // signals the last item, may not be omitted
+};
+
+/* layers is an ordered list of layouts, used to cycle through */
+static enum layout_id landscape_layers[] = {
+  Full, // First layout is the default layout on startup
+  Special,
+  NumLayouts // signals the last item, may not be omitted
+};
+
+#endif // config_h_INCLUDED

--- a/config.mobintl.h
+++ b/config.mobintl.h
@@ -1,5 +1,5 @@
-#ifndef config_def_h_INCLUDED
-#define config_def_h_INCLUDED
+#ifndef config_h_INCLUDED
+#define config_h_INCLUDED
 
 #define DEFAULT_FONT "Sans 14"
 #define DEFAULT_ROUNDING 5
@@ -31,7 +31,7 @@ struct clr_scheme schemes[] = {
 /* layers is an ordered list of layouts, used to cycle through */
 static enum layout_id layers[] = {
   Full, // First layout is the default layout on startup
-  Special, 
+  Special,
   NumLayouts // signals the last item, may not be omitted
 };
 
@@ -42,4 +42,4 @@ static enum layout_id landscape_layers[] = {
   NumLayouts // signals the last item, may not be omitted
 };
 
-#endif // config_def_h_INCLUDED
+#endif // config_h_INCLUDED

--- a/keymap.deskintl.h
+++ b/keymap.deskintl.h
@@ -1,0 +1,1471 @@
+#define NUMKEYMAPS 1
+
+static const char *keymap_names[] = {"latin"};
+
+static const char *keymaps[NUMKEYMAPS] = {
+
+  // LATIN
+  "xkb_keymap {\
+xkb_keycodes \"(unnamed)\" {\
+        minimum = 8;\
+        maximum = 255;\
+        <ESC>                = 9;\
+        <AE01>               = 10;\
+        <AE02>               = 11;\
+        <AE03>               = 12;\
+        <AE04>               = 13;\
+        <AE05>               = 14;\
+        <AE06>               = 15;\
+        <AE07>               = 16;\
+        <AE08>               = 17;\
+        <AE09>               = 18;\
+        <AE10>               = 19;\
+        <AE11>               = 20;\
+        <AE12>               = 21;\
+        <BKSP>               = 22;\
+        <TAB>                = 23;\
+        <AD01>               = 24;\
+        <AD02>               = 25;\
+        <AD03>               = 26;\
+        <AD04>               = 27;\
+        <AD05>               = 28;\
+        <AD06>               = 29;\
+        <AD07>               = 30;\
+        <AD08>               = 31;\
+        <AD09>               = 32;\
+        <AD10>               = 33;\
+        <AD11>               = 34;\
+        <AD12>               = 35;\
+        <RTRN>               = 36;\
+        <LCTL>               = 37;\
+        <AC01>               = 38;\
+        <AC02>               = 39;\
+        <AC03>               = 40;\
+        <AC04>               = 41;\
+        <AC05>               = 42;\
+        <AC06>               = 43;\
+        <AC07>               = 44;\
+        <AC08>               = 45;\
+        <AC09>               = 46;\
+        <AC10>               = 47;\
+        <AC11>               = 48;\
+        <TLDE>               = 49;\
+        <LFSH>               = 50;\
+        <BKSL>               = 51;\
+        <AB01>               = 52;\
+        <AB02>               = 53;\
+        <AB03>               = 54;\
+        <AB04>               = 55;\
+        <AB05>               = 56;\
+        <AB06>               = 57;\
+        <AB07>               = 58;\
+        <AB08>               = 59;\
+        <AB09>               = 60;\
+        <AB10>               = 61;\
+        <RTSH>               = 62;\
+        <KPMU>               = 63;\
+        <LALT>               = 64;\
+        <SPCE>               = 65;\
+        <CAPS>               = 66;\
+        <FK01>               = 67;\
+        <FK02>               = 68;\
+        <FK03>               = 69;\
+        <FK04>               = 70;\
+        <FK05>               = 71;\
+        <FK06>               = 72;\
+        <FK07>               = 73;\
+        <FK08>               = 74;\
+        <FK09>               = 75;\
+        <FK10>               = 76;\
+        <NMLK>               = 77;\
+        <SCLK>               = 78;\
+        <KP7>                = 79;\
+        <KP8>                = 80;\
+        <KP9>                = 81;\
+        <KPSU>               = 82;\
+        <KP4>                = 83;\
+        <KP5>                = 84;\
+        <KP6>                = 85;\
+        <KPAD>               = 86;\
+        <KP1>                = 87;\
+        <KP2>                = 88;\
+        <KP3>                = 89;\
+        <KP0>                = 90;\
+        <KPDL>               = 91;\
+        <LVL3>               = 92;\
+        <LSGT>               = 94;\
+        <FK11>               = 95;\
+        <FK12>               = 96;\
+        <AB11>               = 97;\
+        <KATA>               = 98;\
+        <HIRA>               = 99;\
+        <HENK>               = 100;\
+        <HKTG>               = 101;\
+        <MUHE>               = 102;\
+        <JPCM>               = 103;\
+        <KPEN>               = 104;\
+        <RCTL>               = 105;\
+        <KPDV>               = 106;\
+        <PRSC>               = 107;\
+        <RALT>               = 108;\
+        <LNFD>               = 109;\
+        <HOME>               = 110;\
+        <UP>                 = 111;\
+        <PGUP>               = 112;\
+        <LEFT>               = 113;\
+        <RGHT>               = 114;\
+        <END>                = 115;\
+        <DOWN>               = 116;\
+        <PGDN>               = 117;\
+        <INS>                = 118;\
+        <DELE>               = 119;\
+        <I120>               = 120;\
+        <MUTE>               = 121;\
+        <VOL->               = 122;\
+        <VOL+>               = 123;\
+        <POWR>               = 124;\
+        <KPEQ>               = 125;\
+        <I126>               = 126;\
+        <PAUS>               = 127;\
+        <I128>               = 128;\
+        <I129>               = 129;\
+        <HNGL>               = 130;\
+        <HJCV>               = 131;\
+        <AE13>               = 132;\
+        <LWIN>               = 133;\
+        <RWIN>               = 134;\
+        <COMP>               = 135;\
+        <STOP>               = 136;\
+        <AGAI>               = 137;\
+        <PROP>               = 138;\
+        <UNDO>               = 139;\
+        <FRNT>               = 140;\
+        <COPY>               = 141;\
+        <OPEN>               = 142;\
+        <PAST>               = 143;\
+        <FIND>               = 144;\
+        <CUT>                = 145;\
+        <HELP>               = 146;\
+        <I147>               = 147;\
+        <I148>               = 148;\
+        <I149>               = 149;\
+        <I150>               = 150;\
+        <I151>               = 151;\
+        <I152>               = 152;\
+        <I153>               = 153;\
+        <I154>               = 154;\
+        <I155>               = 155;\
+        <I156>               = 156;\
+        <I157>               = 157;\
+        <I158>               = 158;\
+        <I159>               = 159;\
+        <I160>               = 160;\
+        <I161>               = 161;\
+        <I162>               = 162;\
+        <I163>               = 163;\
+        <I164>               = 164;\
+        <I165>               = 165;\
+        <I166>               = 166;\
+        <I167>               = 167;\
+        <I168>               = 168;\
+        <I169>               = 169;\
+        <I170>               = 170;\
+        <I171>               = 171;\
+        <I172>               = 172;\
+        <I173>               = 173;\
+        <I174>               = 174;\
+        <I175>               = 175;\
+        <I176>               = 176;\
+        <I177>               = 177;\
+        <I178>               = 178;\
+        <I179>               = 179;\
+        <I180>               = 180;\
+        <I181>               = 181;\
+        <I182>               = 182;\
+        <I183>               = 183;\
+        <I184>               = 184;\
+        <I185>               = 185;\
+        <I186>               = 186;\
+        <I187>               = 187;\
+        <I188>               = 188;\
+        <I189>               = 189;\
+        <I190>               = 190;\
+        <FK13>               = 191;\
+        <FK14>               = 192;\
+        <FK15>               = 193;\
+        <FK16>               = 194;\
+        <FK17>               = 195;\
+        <FK18>               = 196;\
+        <FK19>               = 197;\
+        <FK20>               = 198;\
+        <FK21>               = 199;\
+        <FK22>               = 200;\
+        <FK23>               = 201;\
+        <FK24>               = 202;\
+        <MDSW>               = 203;\
+        <ALT>                = 204;\
+        <META>               = 205;\
+        <SUPR>               = 206;\
+        <HYPR>               = 207;\
+        <I208>               = 208;\
+        <I209>               = 209;\
+        <I210>               = 210;\
+        <I211>               = 211;\
+        <I212>               = 212;\
+        <I213>               = 213;\
+        <I214>               = 214;\
+        <I215>               = 215;\
+        <I216>               = 216;\
+        <I217>               = 217;\
+        <I218>               = 218;\
+        <I219>               = 219;\
+        <I220>               = 220;\
+        <I221>               = 221;\
+        <I222>               = 222;\
+        <I223>               = 223;\
+        <I224>               = 224;\
+        <I225>               = 225;\
+        <I226>               = 226;\
+        <I227>               = 227;\
+        <I228>               = 228;\
+        <I229>               = 229;\
+        <I230>               = 230;\
+        <I231>               = 231;\
+        <I232>               = 232;\
+        <I233>               = 233;\
+        <I234>               = 234;\
+        <I235>               = 235;\
+        <I236>               = 236;\
+        <I237>               = 237;\
+        <I238>               = 238;\
+        <I239>               = 239;\
+        <I240>               = 240;\
+        <I241>               = 241;\
+        <I242>               = 242;\
+        <I243>               = 243;\
+        <I244>               = 244;\
+        <I245>               = 245;\
+        <I246>               = 246;\
+        <I247>               = 247;\
+        <I248>               = 248;\
+        <I249>               = 249;\
+        <I250>               = 250;\
+        <I251>               = 251;\
+        <I252>               = 252;\
+        <I253>               = 253;\
+        <I254>               = 254;\
+        <I255>               = 255;\
+        indicator 1 = \"Caps Lock\";\
+        indicator 2 = \"Num Lock\";\
+        indicator 3 = \"Scroll Lock\";\
+        indicator 4 = \"Compose\";\
+        indicator 5 = \"Kana\";\
+        indicator 6 = \"Sleep\";\
+        indicator 7 = \"Suspend\";\
+        indicator 8 = \"Mute\";\
+        indicator 9 = \"Misc\";\
+        indicator 10 = \"Mail\";\
+        indicator 11 = \"Charging\";\
+        indicator 12 = \"Shift Lock\";\
+        indicator 13 = \"Group 2\";\
+        indicator 14 = \"Mouse Keys\";\
+        alias <AC12>         = <BKSL>;\
+        alias <MENU>         = <COMP>;\
+        alias <HZTG>         = <TLDE>;\
+        alias <LMTA>         = <LWIN>;\
+        alias <RMTA>         = <RWIN>;\
+        alias <ALGR>         = <RALT>;\
+        alias <KPPT>         = <I129>;\
+        alias <LatQ>         = <AD01>;\
+        alias <LatW>         = <AD02>;\
+        alias <LatE>         = <AD03>;\
+        alias <LatR>         = <AD04>;\
+        alias <LatT>         = <AD05>;\
+        alias <LatY>         = <AD06>;\
+        alias <LatU>         = <AD07>;\
+        alias <LatI>         = <AD08>;\
+        alias <LatO>         = <AD09>;\
+        alias <LatP>         = <AD10>;\
+        alias <LatA>         = <AC01>;\
+        alias <LatS>         = <AC02>;\
+        alias <LatD>         = <AC03>;\
+        alias <LatF>         = <AC04>;\
+        alias <LatG>         = <AC05>;\
+        alias <LatH>         = <AC06>;\
+        alias <LatJ>         = <AC07>;\
+        alias <LatK>         = <AC08>;\
+        alias <LatL>         = <AC09>;\
+        alias <LatZ>         = <AB01>;\
+        alias <LatX>         = <AB02>;\
+        alias <LatC>         = <AB03>;\
+        alias <LatV>         = <AB04>;\
+        alias <LatB>         = <AB05>;\
+        alias <LatN>         = <AB06>;\
+        alias <LatM>         = <AB07>;\
+};\
+\
+xkb_types \"(unnamed)\" {\
+        virtual_modifiers NumLock,Alt,LevelThree,LAlt,RAlt,RControl,LControl,ScrollLock,LevelFive,AltGr,Meta,Super,Hyper;\
+\
+        type \"ONE_LEVEL\" {\
+                modifiers= none;\
+                level_name[Level1]= \"Any\";\
+        };\
+        type \"TWO_LEVEL\" {\
+                modifiers= Shift;\
+                map[Shift]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+        };\
+        type \"ALPHABETIC\" {\
+                modifiers= Shift+Lock;\
+                map[Shift]= Level2;\
+                map[Lock]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Caps\";\
+        };\
+        type \"SHIFT+ALT\" {\
+                modifiers= Shift+Alt;\
+                map[Shift+Alt]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift+Alt\";\
+        };\
+        type \"PC_SUPER_LEVEL2\" {\
+                modifiers= Mod4;\
+                map[Mod4]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Super\";\
+        };\
+        type \"PC_CONTROL_LEVEL2\" {\
+                modifiers= Control;\
+                map[Control]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Control\";\
+        };\
+        type \"PC_LCONTROL_LEVEL2\" {\
+                modifiers= LControl;\
+                map[LControl]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"LControl\";\
+        };\
+        type \"PC_RCONTROL_LEVEL2\" {\
+                modifiers= RControl;\
+                map[RControl]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"RControl\";\
+        };\
+        type \"PC_ALT_LEVEL2\" {\
+                modifiers= Alt;\
+                map[Alt]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Alt\";\
+        };\
+        type \"PC_LALT_LEVEL2\" {\
+                modifiers= LAlt;\
+                map[LAlt]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"LAlt\";\
+        };\
+        type \"PC_RALT_LEVEL2\" {\
+                modifiers= RAlt;\
+                map[RAlt]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"RAlt\";\
+        };\
+        type \"CTRL+ALT\" {\
+                modifiers= Shift+Control+Alt+LevelThree;\
+                map[Shift]= Level2;\
+                preserve[Shift]= Shift;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                preserve[Shift+LevelThree]= Shift;\
+                map[Control+Alt]= Level5;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"Ctrl+Alt\";\
+        };\
+        type \"LOCAL_EIGHT_LEVEL\" {\
+                modifiers= Shift+Lock+Control+LevelThree;\
+                map[Shift]= Level2;\
+                map[Lock]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+Lock+LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock+LevelThree]= Level4;\
+                map[Control]= Level5;\
+                map[Shift+Lock+Control]= Level5;\
+                map[Shift+Control]= Level6;\
+                map[Lock+Control]= Level6;\
+                map[Control+LevelThree]= Level7;\
+                map[Shift+Lock+Control+LevelThree]= Level7;\
+                map[Shift+Control+LevelThree]= Level8;\
+                map[Lock+Control+LevelThree]= Level8;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Level3\";\
+                level_name[Level4]= \"Shift Level3\";\
+                level_name[Level5]= \"Ctrl\";\
+                level_name[Level6]= \"Shift Ctrl\";\
+                level_name[Level7]= \"Level3 Ctrl\";\
+                level_name[Level8]= \"Shift Level3 Ctrl\";\
+        };\
+        type \"THREE_LEVEL\" {\
+                modifiers= Shift+LevelThree;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level3;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Level3\";\
+        };\
+        type \"EIGHT_LEVEL\" {\
+                modifiers= Shift+LevelThree+LevelFive;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[LevelFive]= Level5;\
+                map[Shift+LevelFive]= Level6;\
+                map[LevelThree+LevelFive]= Level7;\
+                map[Shift+LevelThree+LevelFive]= Level8;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"X\";\
+                level_name[Level6]= \"X Shift\";\
+                level_name[Level7]= \"X Alt Base\";\
+                level_name[Level8]= \"X Shift Alt\";\
+        };\
+        type \"EIGHT_LEVEL_ALPHABETIC\" {\
+                modifiers= Shift+Lock+LevelThree+LevelFive;\
+                map[Shift]= Level2;\
+                map[Lock]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock+LevelThree]= Level4;\
+                map[Shift+Lock+LevelThree]= Level3;\
+                map[LevelFive]= Level5;\
+                map[Shift+LevelFive]= Level6;\
+                map[Lock+LevelFive]= Level6;\
+                map[LevelThree+LevelFive]= Level7;\
+                map[Shift+LevelThree+LevelFive]= Level8;\
+                map[Lock+LevelThree+LevelFive]= Level8;\
+                map[Shift+Lock+LevelThree+LevelFive]= Level7;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"X\";\
+                level_name[Level6]= \"X Shift\";\
+                level_name[Level7]= \"X Alt Base\";\
+                level_name[Level8]= \"X Shift Alt\";\
+        };\
+        type \"EIGHT_LEVEL_LEVEL_FIVE_LOCK\" {\
+                modifiers= Shift+Lock+NumLock+LevelThree+LevelFive;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[LevelFive]= Level5;\
+                map[Shift+LevelFive]= Level6;\
+                preserve[Shift+LevelFive]= Shift;\
+                map[LevelThree+LevelFive]= Level7;\
+                map[Shift+LevelThree+LevelFive]= Level8;\
+                map[NumLock]= Level5;\
+                map[Shift+NumLock]= Level6;\
+                preserve[Shift+NumLock]= Shift;\
+                map[NumLock+LevelThree]= Level7;\
+                map[Shift+NumLock+LevelThree]= Level8;\
+                map[Shift+NumLock+LevelFive]= Level2;\
+                map[NumLock+LevelThree+LevelFive]= Level3;\
+                map[Shift+NumLock+LevelThree+LevelFive]= Level4;\
+                map[Shift+Lock]= Level2;\
+                map[Lock+LevelThree]= Level3;\
+                map[Shift+Lock+LevelThree]= Level4;\
+                map[Lock+LevelFive]= Level5;\
+                map[Shift+Lock+LevelFive]= Level6;\
+                preserve[Shift+Lock+LevelFive]= Shift;\
+                map[Lock+LevelThree+LevelFive]= Level7;\
+                map[Shift+Lock+LevelThree+LevelFive]= Level8;\
+                map[Lock+NumLock]= Level5;\
+                map[Shift+Lock+NumLock]= Level6;\
+                preserve[Shift+Lock+NumLock]= Shift;\
+                map[Lock+NumLock+LevelThree]= Level7;\
+                map[Shift+Lock+NumLock+LevelThree]= Level8;\
+                map[Shift+Lock+NumLock+LevelFive]= Level2;\
+                map[Lock+NumLock+LevelThree+LevelFive]= Level3;\
+                map[Shift+Lock+NumLock+LevelThree+LevelFive]= Level4;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"X\";\
+                level_name[Level6]= \"X Shift\";\
+                level_name[Level7]= \"X Alt Base\";\
+                level_name[Level8]= \"X Shift Alt\";\
+        };\
+        type \"EIGHT_LEVEL_ALPHABETIC_LEVEL_FIVE_LOCK\" {\
+                modifiers= Shift+Lock+NumLock+LevelThree+LevelFive;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[LevelFive]= Level5;\
+                map[Shift+LevelFive]= Level6;\
+                preserve[Shift+LevelFive]= Shift;\
+                map[LevelThree+LevelFive]= Level7;\
+                map[Shift+LevelThree+LevelFive]= Level8;\
+                map[NumLock]= Level5;\
+                map[Shift+NumLock]= Level6;\
+                preserve[Shift+NumLock]= Shift;\
+                map[NumLock+LevelThree]= Level7;\
+                map[Shift+NumLock+LevelThree]= Level8;\
+                map[Shift+NumLock+LevelFive]= Level2;\
+                map[NumLock+LevelThree+LevelFive]= Level3;\
+                map[Shift+NumLock+LevelThree+LevelFive]= Level4;\
+                map[Lock]= Level2;\
+                map[Lock+LevelThree]= Level3;\
+                map[Shift+Lock+LevelThree]= Level4;\
+                map[Lock+LevelFive]= Level5;\
+                map[Shift+Lock+LevelFive]= Level6;\
+                map[Lock+LevelThree+LevelFive]= Level7;\
+                map[Shift+Lock+LevelThree+LevelFive]= Level8;\
+                map[Lock+NumLock]= Level5;\
+                map[Shift+Lock+NumLock]= Level6;\
+                map[Lock+NumLock+LevelThree]= Level7;\
+                map[Shift+Lock+NumLock+LevelThree]= Level8;\
+                map[Lock+NumLock+LevelFive]= Level2;\
+                map[Lock+NumLock+LevelThree+LevelFive]= Level4;\
+                map[Shift+Lock+NumLock+LevelThree+LevelFive]= Level3;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"X\";\
+                level_name[Level6]= \"X Shift\";\
+                level_name[Level7]= \"X Alt Base\";\
+                level_name[Level8]= \"X Shift Alt\";\
+        };\
+        type \"EIGHT_LEVEL_SEMIALPHABETIC\" {\
+                modifiers= Shift+Lock+LevelThree+LevelFive;\
+                map[Shift]= Level2;\
+                map[Lock]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock+LevelThree]= Level3;\
+                preserve[Lock+LevelThree]= Lock;\
+                map[Shift+Lock+LevelThree]= Level4;\
+                preserve[Shift+Lock+LevelThree]= Lock;\
+                map[LevelFive]= Level5;\
+                map[Shift+LevelFive]= Level6;\
+                map[Lock+LevelFive]= Level6;\
+                preserve[Lock+LevelFive]= Lock;\
+                map[Shift+Lock+LevelFive]= Level6;\
+                preserve[Shift+Lock+LevelFive]= Lock;\
+                map[LevelThree+LevelFive]= Level7;\
+                map[Shift+LevelThree+LevelFive]= Level8;\
+                map[Lock+LevelThree+LevelFive]= Level7;\
+                preserve[Lock+LevelThree+LevelFive]= Lock;\
+                map[Shift+Lock+LevelThree+LevelFive]= Level8;\
+                preserve[Shift+Lock+LevelThree+LevelFive]= Lock;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"X\";\
+                level_name[Level6]= \"X Shift\";\
+                level_name[Level7]= \"X Alt Base\";\
+                level_name[Level8]= \"X Shift Alt\";\
+        };\
+        type \"FOUR_LEVEL\" {\
+                modifiers= Shift+LevelThree;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+        };\
+        type \"FOUR_LEVEL_ALPHABETIC\" {\
+                modifiers= Shift+Lock+LevelThree;\
+                map[Shift]= Level2;\
+                map[Lock]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock+LevelThree]= Level4;\
+                map[Shift+Lock+LevelThree]= Level3;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+        };\
+        type \"FOUR_LEVEL_SEMIALPHABETIC\" {\
+                modifiers= Shift+Lock+LevelThree;\
+                map[Shift]= Level2;\
+                map[Lock]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock+LevelThree]= Level3;\
+                preserve[Lock+LevelThree]= Lock;\
+                map[Shift+Lock+LevelThree]= Level4;\
+                preserve[Shift+Lock+LevelThree]= Lock;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+        };\
+        type \"FOUR_LEVEL_MIXED_KEYPAD\" {\
+                modifiers= Shift+NumLock+LevelThree;\
+                map[NumLock]= Level2;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[NumLock+LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Shift+NumLock+LevelThree]= Level4;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Number\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+        };\
+        type \"FOUR_LEVEL_X\" {\
+                modifiers= Shift+Control+Alt+LevelThree;\
+                map[LevelThree]= Level2;\
+                map[Shift+LevelThree]= Level3;\
+                map[Control+Alt]= Level4;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Alt Base\";\
+                level_name[Level3]= \"Shift Alt\";\
+                level_name[Level4]= \"Ctrl+Alt\";\
+        };\
+        type \"SEPARATE_CAPS_AND_SHIFT_ALPHABETIC\" {\
+                modifiers= Shift+Lock+LevelThree;\
+                map[Shift]= Level2;\
+                map[Lock]= Level4;\
+                preserve[Lock]= Lock;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock+LevelThree]= Level3;\
+                preserve[Lock+LevelThree]= Lock;\
+                map[Shift+Lock+LevelThree]= Level3;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"AltGr Base\";\
+                level_name[Level4]= \"Shift AltGr\";\
+        };\
+        type \"FOUR_LEVEL_PLUS_LOCK\" {\
+                modifiers= Shift+Lock+LevelThree;\
+                map[Shift]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[Lock]= Level5;\
+                map[Shift+Lock]= Level2;\
+                map[Lock+LevelThree]= Level3;\
+                map[Shift+Lock+LevelThree]= Level4;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Shift\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Shift Alt\";\
+                level_name[Level5]= \"Lock\";\
+        };\
+        type \"KEYPAD\" {\
+                modifiers= Shift+NumLock;\
+                map[Shift]= Level2;\
+                map[NumLock]= Level2;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Number\";\
+        };\
+        type \"FOUR_LEVEL_KEYPAD\" {\
+                modifiers= Shift+NumLock+LevelThree;\
+                map[Shift]= Level2;\
+                map[NumLock]= Level2;\
+                map[LevelThree]= Level3;\
+                map[Shift+LevelThree]= Level4;\
+                map[NumLock+LevelThree]= Level4;\
+                map[Shift+NumLock+LevelThree]= Level3;\
+                level_name[Level1]= \"Base\";\
+                level_name[Level2]= \"Number\";\
+                level_name[Level3]= \"Alt Base\";\
+                level_name[Level4]= \"Alt Number\";\
+        };\
+};\
+\
+xkb_compatibility \"(unnamed)\" {\
+        virtual_modifiers NumLock,Alt,LevelThree,LAlt,RAlt,RControl,LControl,ScrollLock,LevelFive,AltGr,Meta,Super,Hyper;\
+\
+        interpret.useModMapMods= AnyLevel;\
+        interpret.repeat= False;\
+        interpret ISO_Level2_Latch+Exactly(Shift) {\
+                useModMapMods=level1;\
+                action= LatchMods(modifiers=Shift,clearLocks,latchToLock);\
+        };\
+        interpret Shift_Lock+AnyOf(Shift+Lock) {\
+                action= LockMods(modifiers=Shift);\
+        };\
+        interpret Num_Lock+AnyOf(all) {\
+                virtualModifier= NumLock;\
+                action= LockMods(modifiers=NumLock);\
+        };\
+        interpret ISO_Level3_Shift+AnyOf(all) {\
+                virtualModifier= LevelThree;\
+                useModMapMods=level1;\
+                action= SetMods(modifiers=LevelThree,clearLocks);\
+        };\
+        interpret ISO_Level3_Latch+AnyOf(all) {\
+                virtualModifier= LevelThree;\
+                useModMapMods=level1;\
+                action= LatchMods(modifiers=LevelThree,clearLocks,latchToLock);\
+        };\
+        interpret ISO_Level3_Lock+AnyOf(all) {\
+                virtualModifier= LevelThree;\
+                useModMapMods=level1;\
+                action= LockMods(modifiers=LevelThree);\
+        };\
+        interpret Alt_L+AnyOf(all) {\
+                virtualModifier= Alt;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Alt_R+AnyOf(all) {\
+                virtualModifier= Alt;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Meta_L+AnyOf(all) {\
+                virtualModifier= Meta;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Meta_R+AnyOf(all) {\
+                virtualModifier= Meta;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Super_L+AnyOf(all) {\
+                virtualModifier= Super;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Super_R+AnyOf(all) {\
+                virtualModifier= Super;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Hyper_L+AnyOf(all) {\
+                virtualModifier= Hyper;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Hyper_R+AnyOf(all) {\
+                virtualModifier= Hyper;\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        interpret Scroll_Lock+AnyOf(all) {\
+                virtualModifier= ScrollLock;\
+                action= LockMods(modifiers=modMapMods);\
+        };\
+        interpret ISO_Level5_Shift+AnyOf(all) {\
+                virtualModifier= LevelFive;\
+                useModMapMods=level1;\
+                action= SetMods(modifiers=LevelFive,clearLocks);\
+        };\
+        interpret ISO_Level5_Latch+AnyOf(all) {\
+                virtualModifier= LevelFive;\
+                useModMapMods=level1;\
+                action= LatchMods(modifiers=LevelFive,clearLocks,latchToLock);\
+        };\
+        interpret ISO_Level5_Lock+AnyOf(all) {\
+                virtualModifier= LevelFive;\
+                useModMapMods=level1;\
+                action= LockMods(modifiers=LevelFive);\
+        };\
+        interpret Mode_switch+AnyOfOrNone(all) {\
+                virtualModifier= AltGr;\
+                useModMapMods=level1;\
+                action= SetGroup(group=+1);\
+        };\
+        interpret ISO_Level3_Shift+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=LevelThree,clearLocks);\
+        };\
+        interpret ISO_Level3_Latch+AnyOfOrNone(all) {\
+                action= LatchMods(modifiers=LevelThree,clearLocks,latchToLock);\
+        };\
+        interpret ISO_Level3_Lock+AnyOfOrNone(all) {\
+                action= LockMods(modifiers=LevelThree);\
+        };\
+        interpret ISO_Group_Latch+AnyOfOrNone(all) {\
+                virtualModifier= AltGr;\
+                useModMapMods=level1;\
+                action= LatchGroup(group=2);\
+        };\
+        interpret ISO_Next_Group+AnyOfOrNone(all) {\
+                virtualModifier= AltGr;\
+                useModMapMods=level1;\
+                action= LockGroup(group=+1);\
+        };\
+        interpret ISO_Prev_Group+AnyOfOrNone(all) {\
+                virtualModifier= AltGr;\
+                useModMapMods=level1;\
+                action= LockGroup(group=-1);\
+        };\
+        interpret ISO_First_Group+AnyOfOrNone(all) {\
+                action= LockGroup(group=1);\
+        };\
+        interpret ISO_Last_Group+AnyOfOrNone(all) {\
+                action= LockGroup(group=2);\
+        };\
+        interpret KP_1+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=+1);\
+        };\
+        interpret KP_End+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=+1);\
+        };\
+        interpret KP_2+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+0,y=+1);\
+        };\
+        interpret KP_Down+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+0,y=+1);\
+        };\
+        interpret KP_3+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=+1);\
+        };\
+        interpret KP_Next+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=+1);\
+        };\
+        interpret KP_4+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=+0);\
+        };\
+        interpret KP_Left+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=+0);\
+        };\
+        interpret KP_6+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=+0);\
+        };\
+        interpret KP_Right+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=+0);\
+        };\
+        interpret KP_7+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=-1);\
+        };\
+        interpret KP_Home+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=-1);\
+        };\
+        interpret KP_8+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+0,y=-1);\
+        };\
+        interpret KP_Up+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+0,y=-1);\
+        };\
+        interpret KP_9+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=-1);\
+        };\
+        interpret KP_Prior+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=-1);\
+        };\
+        interpret KP_5+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= PtrBtn(button=default);\
+        };\
+        interpret KP_Begin+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= PtrBtn(button=default);\
+        };\
+        interpret KP_F2+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=1);\
+        };\
+        interpret KP_Divide+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=1);\
+        };\
+        interpret KP_F3+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=2);\
+        };\
+        interpret KP_Multiply+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=2);\
+        };\
+        interpret KP_F4+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=3);\
+        };\
+        interpret KP_Subtract+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=3);\
+        };\
+        interpret KP_Separator+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= PtrBtn(button=default,count=2);\
+        };\
+        interpret KP_Add+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= PtrBtn(button=default,count=2);\
+        };\
+        interpret KP_0+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= LockPtrBtn(button=default,affect=lock);\
+        };\
+        interpret KP_Insert+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= LockPtrBtn(button=default,affect=lock);\
+        };\
+        interpret KP_Decimal+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= LockPtrBtn(button=default,affect=unlock);\
+        };\
+        interpret KP_Delete+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= LockPtrBtn(button=default,affect=unlock);\
+        };\
+        interpret F25+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=1);\
+        };\
+        interpret F26+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SetPtrDflt(affect=button,button=2);\
+        };\
+        interpret F27+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=-1);\
+        };\
+        interpret F29+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=-1);\
+        };\
+        interpret F31+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= PtrBtn(button=default);\
+        };\
+        interpret F33+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=-1,y=+1);\
+        };\
+        interpret F35+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= MovePtr(x=+1,y=+1);\
+        };\
+        interpret Pointer_Button_Dflt+AnyOfOrNone(all) {\
+                action= PtrBtn(button=default);\
+        };\
+        interpret Pointer_Button1+AnyOfOrNone(all) {\
+                action= PtrBtn(button=1);\
+        };\
+        interpret Pointer_Button2+AnyOfOrNone(all) {\
+                action= PtrBtn(button=2);\
+        };\
+        interpret Pointer_Button3+AnyOfOrNone(all) {\
+                action= PtrBtn(button=3);\
+        };\
+        interpret Pointer_DblClick_Dflt+AnyOfOrNone(all) {\
+                action= PtrBtn(button=default,count=2);\
+        };\
+        interpret Pointer_DblClick1+AnyOfOrNone(all) {\
+                action= PtrBtn(button=1,count=2);\
+        };\
+        interpret Pointer_DblClick2+AnyOfOrNone(all) {\
+                action= PtrBtn(button=2,count=2);\
+        };\
+        interpret Pointer_DblClick3+AnyOfOrNone(all) {\
+                action= PtrBtn(button=3,count=2);\
+        };\
+        interpret Pointer_Drag_Dflt+AnyOfOrNone(all) {\
+                action= LockPtrBtn(button=default);\
+        };\
+        interpret Pointer_Drag1+AnyOfOrNone(all) {\
+                action= LockPtrBtn(button=1);\
+        };\
+        interpret Pointer_Drag2+AnyOfOrNone(all) {\
+                action= LockPtrBtn(button=2);\
+        };\
+        interpret Pointer_Drag3+AnyOfOrNone(all) {\
+                action= LockPtrBtn(button=3);\
+        };\
+        interpret Pointer_EnableKeys+AnyOfOrNone(all) {\
+                action= LockControls(controls=MouseKeys);\
+        };\
+        interpret Pointer_Accelerate+AnyOfOrNone(all) {\
+                action= LockControls(controls=MouseKeysAccel);\
+        };\
+        interpret Pointer_DfltBtnNext+AnyOfOrNone(all) {\
+                action= SetPtrDflt(affect=button,button=+1);\
+        };\
+        interpret Pointer_DfltBtnPrev+AnyOfOrNone(all) {\
+                action= SetPtrDflt(affect=button,button=-1);\
+        };\
+        interpret AccessX_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=AccessXKeys);\
+        };\
+        interpret AccessX_Feedback_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=AccessXFeedback);\
+        };\
+        interpret RepeatKeys_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=RepeatKeys);\
+        };\
+        interpret SlowKeys_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=SlowKeys);\
+        };\
+        interpret BounceKeys_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=BounceKeys);\
+        };\
+        interpret StickyKeys_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=StickyKeys);\
+        };\
+        interpret MouseKeys_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=MouseKeys);\
+        };\
+        interpret MouseKeys_Accel_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=MouseKeysAccel);\
+        };\
+        interpret Overlay1_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=none);\
+        };\
+        interpret Overlay2_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=none);\
+        };\
+        interpret AudibleBell_Enable+AnyOfOrNone(all) {\
+                action= LockControls(controls=AudibleBell);\
+        };\
+        interpret Terminate_Server+AnyOfOrNone(all) {\
+                action= Terminate();\
+        };\
+        interpret Alt_L+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Alt,clearLocks);\
+        };\
+        interpret Alt_R+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Alt,clearLocks);\
+        };\
+        interpret Meta_L+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Meta,clearLocks);\
+        };\
+        interpret Meta_R+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Meta,clearLocks);\
+        };\
+        interpret Super_L+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Super,clearLocks);\
+        };\
+        interpret Super_R+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Super,clearLocks);\
+        };\
+        interpret Hyper_L+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Hyper,clearLocks);\
+        };\
+        interpret Hyper_R+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Hyper,clearLocks);\
+        };\
+        interpret Shift_L+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=Shift,clearLocks);\
+        };\
+        interpret XF86Switch_VT_1+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=1,!same);\
+        };\
+        interpret XF86Switch_VT_2+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=2,!same);\
+        };\
+        interpret XF86Switch_VT_3+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=3,!same);\
+        };\
+        interpret XF86Switch_VT_4+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=4,!same);\
+        };\
+        interpret XF86Switch_VT_5+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=5,!same);\
+        };\
+        interpret XF86Switch_VT_6+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=6,!same);\
+        };\
+        interpret XF86Switch_VT_7+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=7,!same);\
+        };\
+        interpret XF86Switch_VT_8+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=8,!same);\
+        };\
+        interpret XF86Switch_VT_9+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=9,!same);\
+        };\
+        interpret XF86Switch_VT_10+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=10,!same);\
+        };\
+        interpret XF86Switch_VT_11+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=11,!same);\
+        };\
+        interpret XF86Switch_VT_12+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= SwitchScreen(screen=12,!same);\
+        };\
+        interpret XF86LogGrabInfo+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= Private(type=0x86,data[0]=0x50,data[1]=0x72,data[2]=0x47,data[3]=0x72,data[4]=0x62,data[5]=0x73,data[6]=0x00);\
+        };\
+        interpret XF86LogWindowTree+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= Private(type=0x86,data[0]=0x50,data[1]=0x72,data[2]=0x57,data[3]=0x69,data[4]=0x6e,data[5]=0x73,data[6]=0x00);\
+        };\
+        interpret XF86Next_VMode+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= Private(type=0x86,data[0]=0x2b,data[1]=0x56,data[2]=0x4d,data[3]=0x6f,data[4]=0x64,data[5]=0x65,data[6]=0x00);\
+        };\
+        interpret XF86Prev_VMode+AnyOfOrNone(all) {\
+                repeat= True;\
+                action= Private(type=0x86,data[0]=0x2d,data[1]=0x56,data[2]=0x4d,data[3]=0x6f,data[4]=0x64,data[5]=0x65,data[6]=0x00);\
+        };\
+        interpret ISO_Level5_Shift+AnyOfOrNone(all) {\
+                action= SetMods(modifiers=LevelFive,clearLocks);\
+        };\
+        interpret ISO_Level5_Latch+AnyOfOrNone(all) {\
+                action= LatchMods(modifiers=LevelFive,clearLocks,latchToLock);\
+        };\
+        interpret ISO_Level5_Lock+AnyOfOrNone(all) {\
+                action= LockMods(modifiers=LevelFive);\
+        };\
+        interpret Caps_Lock+AnyOfOrNone(all) {\
+                action= LockMods(modifiers=Lock);\
+        };\
+        interpret Any+Exactly(Lock) {\
+                action= LockMods(modifiers=Lock);\
+        };\
+        interpret Any+AnyOf(all) {\
+                action= SetMods(modifiers=modMapMods,clearLocks);\
+        };\
+        indicator \"Caps Lock\" {\
+                whichModState= locked;\
+                modifiers= Lock;\
+        };\
+        indicator \"Num Lock\" {\
+                whichModState= locked;\
+                modifiers= NumLock;\
+        };\
+        indicator \"Scroll Lock\" {\
+                whichModState= locked;\
+                modifiers= ScrollLock;\
+        };\
+        indicator \"Shift Lock\" {\
+                whichModState= locked;\
+                modifiers= Shift;\
+        };\
+        indicator \"Group 2\" {\
+                groups= 0xfe;\
+        };\
+        indicator \"Mouse Keys\" {\
+                controls= MouseKeys;\
+        };\
+};\
+\
+xkb_symbols \"(unnamed)\" {\
+        name[group1]=\"wvkbd\";\
+\
+        key <ESC>                {	[          Escape ] };\
+        key <AE01>               {	[               1,          exclam, F1 ] };\
+        key <AE02>               {	[               2,              at, F2 ] };\
+        key <AE03>               {	[               3,      numbersign, F3 ] };\
+        key <AE04>               {	[               4,          dollar, F4 ] };\
+        key <AE05>               {	[               5,         percent, F5 ] };\
+        key <AE06>               {	[               6,     asciicircum, F6 ] };\
+        key <AE07>               {	[               7,       ampersand, F7 ] };\
+        key <AE08>               {	[               8,        asterisk, F8 ] };\
+        key <AE09>               {	[               9,       parenleft, F9 ] };\
+        key <AE10>               {	[               0,      parenright, F10 ] };\
+        key <AE11>               {	[           minus,      underscore, EuroSign ] };\
+        key <AE12>               {	[           equal,            plus, sterling ] };\
+        key <BKSP>               {	[       BackSpace,       BackSpace ] };\
+        key <TAB>                {	[             Tab,    ISO_Left_Tab ] };\
+        key <AD01>               {	[               q,               Q, 1 ] };\
+        key <AD02>               {	[               w,               W, 2 ] };\
+        key <AD03>               {	[               e,               E, 3 ] };\
+        key <AD04>               {	[               r,               R, 4 ] };\
+        key <AD05>               {	[               t,               T, 5 ] };\
+        key <AD06>               {	[               y,               Y, 6 ] };\
+        key <AD07>               {	[               u,               U, 7 ] };\
+        key <AD08>               {	[               i,               I, 8 ] };\
+        key <AD09>               {	[               o,               O, 9 ] };\
+        key <AD10>               {	[               p,               P, 0 ] };\
+        key <AD11>               {	[     bracketleft,       braceleft ] };\
+        key <AD12>               {	[    bracketright,      braceright ] };\
+        key <RTRN>               {	[          Return ] };\
+        key <LCTL>               {	[       Control_L ] };\
+        key <AC01>               {	[               a,               A, minus ] };\
+        key <AC02>               {	[               s,               S, at ] };\
+        key <AC03>               {	[               d,               D, asterisk ] };\
+        key <AC04>               {	[               f,               F, asciicircum ] };\
+        key <AC05>               {	[               g,               G, colon ] };\
+        key <AC06>               {	[               h,               H, semicolon ] };\
+        key <AC07>               {	[               j,               J, parenleft ] };\
+        key <AC08>               {	[               k,               K, parenright ] };\
+        key <AC09>               {	[               l,               L, asciitilde ] };\
+        key <AC10>               {	[       semicolon,           colon ] };\
+        key <AC11>               {	[      apostrophe,        quotedbl ] };\
+        key <TLDE>               {	[           grave,      asciitilde ] };\
+        key <LFSH>               {	[         Shift_L ] };\
+        key <BKSL>               {	[       backslash,             bar ] };\
+        key <AB01>               {	[               z,               Z, slash ] };\
+        key <AB02>               {	[               x,               X, apostrophe ] };\
+        key <AB03>               {	[               c,               C, quotedbl ] };\
+        key <AB04>               {	[               v,               V, plus ] };\
+        key <AB05>               {	[               b,               B, equal ] };\
+        key <AB06>               {	[               n,               N, question ] };\
+        key <AB07>               {	[               m,               M, exclam ] };\
+        key <AB08>               {	[           comma,            less, backslash] };\
+        key <AB09>               {	[          period,         greater, bar ] };\
+        key <AB10>               {	[           slash,        question ] };\
+        key <I147>               {  [      exclamdown,   questiondown, exclamdown ] };\
+        key <RTSH>               {	[         Shift_R ] };\
+        key <KPMU>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ]\
+        };\
+        key <LALT>               {	[           Alt_L,          Meta_L ] };\
+        key <SPCE>               {	[           space ] };\
+        key <CAPS>               {	[       Caps_Lock ] };\
+        key <FK01>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F1,              F1,              F1,              F1, XF86Switch_VT_1 ]\
+        };\
+        key <FK02>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F2,              F2,              F2,              F2, XF86Switch_VT_2 ]\
+        };\
+        key <FK03>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F3,              F3,              F3,              F3, XF86Switch_VT_3 ]\
+        };\
+        key <FK04>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F4,              F4,              F4,              F4, XF86Switch_VT_4 ]\
+        };\
+        key <FK05>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F5,              F5,              F5,              F5, XF86Switch_VT_5 ]\
+        };\
+        key <FK06>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F6,              F6,              F6,              F6, XF86Switch_VT_6 ]\
+        };\
+        key <FK07>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F7,              F7,              F7,              F7, XF86Switch_VT_7 ]\
+        };\
+        key <FK08>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F8,              F8,              F8,              F8, XF86Switch_VT_8 ]\
+        };\
+        key <FK09>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [              F9,              F9,              F9,              F9, XF86Switch_VT_9 ]\
+        };\
+        key <FK10>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [             F10,             F10,             F10,             F10, XF86Switch_VT_10 ]\
+        };\
+        key <NMLK>               {	[        Num_Lock ] };\
+        key <SCLK>               {	[     Scroll_Lock ] };\
+        key <KP7>                {	[         KP_Home,            KP_7 ] };\
+        key <KP8>                {	[           KP_Up,            KP_8 ] };\
+        key <KP9>                {	[        KP_Prior,            KP_9 ] };\
+        key <KPSU>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ]\
+        };\
+        key <KP4>                {	[         KP_Left,            KP_4 ] };\
+        key <KP5>                {	[        KP_Begin,            KP_5 ] };\
+        key <KP6>                {	[        KP_Right,            KP_6 ] };\
+        key <KPAD>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ]\
+        };\
+        key <KP1>                {	[          KP_End,            KP_1 ] };\
+        key <KP2>                {	[         KP_Down,            KP_2 ] };\
+        key <KP3>                {	[         KP_Next,            KP_3 ] };\
+        key <KP0>                {	[       KP_Insert,            KP_0 ] };\
+        key <KPDL>               {	[       KP_Delete,      KP_Decimal ] };\
+        key <LVL3>               {	[ ISO_Level3_Shift ] };\
+        key <LSGT>               {	[            less,         greater,             bar,       brokenbar ] };\
+        key <FK11>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [             F11,             F11,             F11,             F11, XF86Switch_VT_11 ]\
+        };\
+        key <FK12>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [             F12,             F12,             F12,             F12, XF86Switch_VT_12 ]\
+        };\
+        key <KATA>               {	[        Katakana ] };\
+        key <HIRA>               {	[        Hiragana ] };\
+        key <HENK>               {	[     Henkan_Mode ] };\
+        key <HKTG>               {	[ Hiragana_Katakana ] };\
+        key <MUHE>               {	[        Muhenkan ] };\
+        key <KPEN>               {	[        KP_Enter ] };\
+        key <RCTL>               {	[       Control_R ] };\
+        key <KPDV>               {\
+                type= \"CTRL+ALT\",\
+                symbols[Group1]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ]\
+        };\
+        key <PRSC>               {\
+                type= \"PC_ALT_LEVEL2\",\
+                symbols[Group1]= [           Print,         Sys_Req ]\
+        };\
+        key <RALT>               {\
+                type= \"TWO_LEVEL\",\
+                symbols[Group1]= [           Alt_R,          Meta_R ]\
+        };\
+        key <LNFD>               {	[        Linefeed ] };\
+        key <HOME>               {	[            Home ] };\
+        key <UP>                 {	[              Up ] };\
+        key <PGUP>               {	[           Prior ] };\
+        key <LEFT>               {	[            Left ] };\
+        key <RGHT>               {	[           Right ] };\
+        key <END>                {	[             End ] };\
+        key <DOWN>               {	[            Down ] };\
+        key <PGDN>               {	[            Next ] };\
+        key <INS>                {	[          Insert ] };\
+        key <DELE>               {	[          Delete ] };\
+        key <MUTE>               {	[   XF86AudioMute ] };\
+        key <VOL->               {	[ XF86AudioLowerVolume ] };\
+        key <VOL+>               {	[ XF86AudioRaiseVolume ] };\
+        key <POWR>               {	[    XF86PowerOff ] };\
+        key <KPEQ>               {	[        KP_Equal ] };\
+        key <I126>               {	[       plusminus ] };\
+        key <PAUS>               {\
+                type= \"PC_CONTROL_LEVEL2\",\
+                symbols[Group1]= [           Pause,           Break ]\
+        };\
+        key <I128>               {	[     XF86LaunchA ] };\
+        key <I129>               {	[      KP_Decimal,      KP_Decimal ] };\
+        key <HNGL>               {	[          Hangul ] };\
+        key <HJCV>               {	[    Hangul_Hanja ] };\
+        key <LWIN>               {	[         Super_L ] };\
+        key <RWIN>               {	[         Super_R ] };\
+        key <COMP>               {	[       U%08X, U%08X ] };\
+        key <STOP>               {	[          Cancel ] };\
+        key <AGAI>               {	[            Redo ] };\
+        key <PROP>               {	[        SunProps ] };\
+        key <UNDO>               {	[            Undo ] };\
+        key <FRNT>               {	[        SunFront ] };\
+        key <COPY>               {	[        XF86Copy ] };\
+        key <OPEN>               {	[        XF86Open ] };\
+        key <PAST>               {	[       XF86Paste ] };\
+        key <FIND>               {	[            Find ] };\
+        key <CUT>                {	[         XF86Cut ] };\
+        key <HELP>               {	[            Help ] };\
+        key <I147>               {	[      XF86MenuKB ] };\
+        key <I148>               {	[  XF86Calculator ] };\
+        key <I150>               {	[       XF86Sleep ] };\
+        key <I151>               {	[      XF86WakeUp ] };\
+        key <I152>               {	[    XF86Explorer ] };\
+        key <I153>               {	[        XF86Send ] };\
+        key <I155>               {	[        XF86Xfer ] };\
+        key <I156>               {	[     XF86Launch1 ] };\
+        key <I157>               {	[     XF86Launch2 ] };\
+        key <I158>               {	[         XF86WWW ] };\
+        key <I159>               {	[         XF86DOS ] };\
+        key <I160>               {	[ XF86ScreenSaver ] };\
+        key <I161>               {	[ XF86RotateWindows ] };\
+        key <I162>               {	[    XF86TaskPane ] };\
+        key <I163>               {	[        XF86Mail ] };\
+        key <I164>               {	[   XF86Favorites ] };\
+        key <I165>               {	[  XF86MyComputer ] };\
+        key <I166>               {	[        XF86Back ] };\
+        key <I167>               {	[     XF86Forward ] };\
+        key <I169>               {	[       XF86Eject ] };\
+        key <I170>               {	[       XF86Eject,       XF86Eject ] };\
+        key <I171>               {	[   XF86AudioNext ] };\
+        key <I172>               {	[   XF86AudioPlay,  XF86AudioPause ] };\
+        key <I173>               {	[   XF86AudioPrev ] };\
+        key <I174>               {	[   XF86AudioStop,       XF86Eject ] };\
+        key <I175>               {	[ XF86AudioRecord ] };\
+        key <I176>               {	[ XF86AudioRewind ] };\
+        key <I177>               {	[       XF86Phone ] };\
+        key <I179>               {	[       XF86Tools ] };\
+        key <I180>               {	[    XF86HomePage ] };\
+        key <I181>               {	[      XF86Reload ] };\
+        key <I182>               {	[       XF86Close ] };\
+        key <I185>               {	[    XF86ScrollUp ] };\
+        key <I186>               {	[  XF86ScrollDown ] };\
+        key <I187>               {	[       parenleft ] };\
+        key <I188>               {	[      parenright ] };\
+        key <I189>               {	[         XF86New ] };\
+        key <I190>               {	[            Redo ] };\
+        key <FK13>               {	[       XF86Tools ] };\
+        key <FK14>               {	[     XF86Launch5 ] };\
+        key <FK15>               {	[     XF86Launch6 ] };\
+        key <FK16>               {	[     XF86Launch7 ] };\
+        key <FK17>               {	[     XF86Launch8 ] };\
+        key <FK18>               {	[     XF86Launch9 ] };\
+        key <FK20>               {	[ XF86AudioMicMute ] };\
+        key <FK21>               {	[ XF86TouchpadToggle ] };\
+        key <FK22>               {	[  XF86TouchpadOn ] };\
+        key <FK23>               {	[ XF86TouchpadOff ] };\
+        key <MDSW>               {	[     Mode_switch ] };\
+        key <ALT>                {	[        NoSymbol,           Alt_L ] };\
+        key <META>               {	[        NoSymbol,          Meta_L ] };\
+        key <SUPR>               {	[        NoSymbol,         Super_L ] };\
+        key <HYPR>               {	[        NoSymbol,         Hyper_L ] };\
+        key <I208>               {	[   XF86AudioPlay ] };\
+        key <I209>               {	[  XF86AudioPause ] };\
+        key <I210>               {	[     XF86Launch3 ] };\
+        key <I211>               {	[     XF86Launch4 ] };\
+        key <I212>               {	[     XF86LaunchB ] };\
+        key <I213>               {	[     XF86Suspend ] };\
+        key <I214>               {	[       XF86Close ] };\
+        key <I215>               {	[   XF86AudioPlay ] };\
+        key <I216>               {	[ XF86AudioForward ] };\
+        key <I218>               {	[           Print ] };\
+        key <I220>               {	[      XF86WebCam ] };\
+        key <I221>               {	[ XF86AudioPreset ] };\
+        key <I223>               {	[        XF86Mail ] };\
+        key <I224>               {	[   XF86Messenger ] };\
+        key <I225>               {	[      XF86Search ] };\
+        key <I226>               {	[          XF86Go ] };\
+        key <I227>               {	[     XF86Finance ] };\
+        key <I228>               {	[        XF86Game ] };\
+        key <I229>               {	[        XF86Shop ] };\
+        key <I231>               {	[          Cancel ] };\
+        key <I232>               {	[ XF86MonBrightnessDown ] };\
+        key <I233>               {	[ XF86MonBrightnessUp ] };\
+        key <I234>               {	[  XF86AudioMedia ] };\
+        key <I235>               {	[     XF86Display ] };\
+        key <I236>               {	[ XF86KbdLightOnOff ] };\
+        key <I237>               {	[ XF86KbdBrightnessDown ] };\
+        key <I238>               {	[ XF86KbdBrightnessUp ] };\
+        key <I239>               {	[        XF86Send ] };\
+        key <I240>               {	[       XF86Reply ] };\
+        key <I241>               {	[ XF86MailForward ] };\
+        key <I242>               {	[        XF86Save ] };\
+        key <I243>               {	[   XF86Documents ] };\
+        key <I244>               {	[     XF86Battery ] };\
+        key <I245>               {	[   XF86Bluetooth ] };\
+        key <I246>               {	[        XF86WLAN ] };\
+        key <I247>               {	[         XF86UWB ] };\
+        key <I254>               {	[        XF86WWAN ] };\
+        key <I255>               {	[      XF86RFKill ] };\
+        modifier_map Shift { <LFSH>, <RTSH> };\
+        modifier_map Lock { <CAPS> };\
+        modifier_map Control { <LCTL>, <RCTL> };\
+        modifier_map Mod1 { <LALT>, <RALT>, <META> };\
+        modifier_map Mod2 { <NMLK> };\
+        modifier_map Mod4 { <LWIN>, <RWIN>, <SUPR>, <HYPR> };\
+        modifier_map Mod5 { <LVL3>, <MDSW> };\
+};\
+\
+};\
+"
+};

--- a/layout.deskintl.h
+++ b/layout.deskintl.h
@@ -1,0 +1,753 @@
+/* constants */
+/* how tall the keyboard should be by default (can be overriden) */
+#define KBD_PIXEL_HEIGHT 400
+
+/* how tall the keyboard should be by default (can be overriden) */
+#define KBD_PIXEL_LANDSCAPE_HEIGHT 400
+
+/* spacing around each key */
+#define KBD_KEY_BORDER 2
+
+/* layout declarations */
+enum layout_id {
+	Full = 0,
+	Special,
+	ComposeA,
+	ComposeE,
+	ComposeY,
+	ComposeU,
+	ComposeI,
+	ComposeO,
+	ComposeW,
+	ComposeR,
+	ComposeT,
+	ComposeP,
+	ComposeS,
+	ComposeD,
+	ComposeF,
+	ComposeG,
+	ComposeH,
+	ComposeJ,
+	ComposeK,
+	ComposeL,
+	ComposeZ,
+	ComposeX,
+	ComposeC,
+	ComposeV,
+	ComposeB,
+	ComposeN,
+	ComposeM,
+	ComposeMath,
+	ComposePunctuation,
+	ComposeBracket,
+	Index,
+	NumLayouts,
+};
+
+static struct key keys_full[], keys_special[],
+  keys_compose_a[],
+  keys_compose_e[], keys_compose_y[], keys_compose_u[], keys_compose_i[],
+  keys_compose_o[], keys_compose_w[], keys_compose_r[], keys_compose_t[],
+  keys_compose_p[], keys_compose_s[], keys_compose_d[], keys_compose_f[],
+  keys_compose_g[], keys_compose_h[], keys_compose_j[], keys_compose_k[],
+  keys_compose_l[], keys_compose_z[], keys_compose_x[], keys_compose_c[],
+  keys_compose_v[], keys_compose_b[], keys_compose_n[], keys_compose_m[],
+  keys_compose_math[], keys_compose_punctuation[], keys_compose_bracket[],
+  keys_index[];
+
+static struct layout layouts[NumLayouts] = {
+  [Full] = {keys_full, "latin", "full", true}, // second parameter is the keymap name
+                                         // third parameter is the layout name
+										 // last parameter indicates if it's an alphabetical/primary layout
+  [Special] = {keys_special, "latin", "special", false},
+  [ComposeA] = {keys_compose_a, "latin"},
+  [ComposeE] = {keys_compose_e, "latin"},
+  [ComposeY] = {keys_compose_y, "latin"},
+  [ComposeU] = {keys_compose_u, "latin"},
+  [ComposeI] = {keys_compose_i, "latin"},
+  [ComposeO] = {keys_compose_o, "latin"},
+  [ComposeW] = {keys_compose_w, "latin"},
+  [ComposeR] = {keys_compose_r, "latin"},
+  [ComposeT] = {keys_compose_t, "latin"},
+  [ComposeP] = {keys_compose_p, "latin"},
+  [ComposeS] = {keys_compose_s, "latin"},
+  [ComposeD] = {keys_compose_d, "latin"},
+  [ComposeF] = {keys_compose_f, "latin"},
+  [ComposeG] = {keys_compose_g, "latin"},
+  [ComposeH] = {keys_compose_h, "latin"},
+  [ComposeJ] = {keys_compose_j, "latin"},
+  [ComposeK] = {keys_compose_k, "latin"},
+  [ComposeL] = {keys_compose_l, "latin"},
+  [ComposeZ] = {keys_compose_z, "latin"},
+  [ComposeX] = {keys_compose_x, "latin"},
+  [ComposeC] = {keys_compose_c, "latin"},
+  [ComposeV] = {keys_compose_v, "latin"},
+  [ComposeB] = {keys_compose_b, "latin"},
+  [ComposeN] = {keys_compose_n, "latin"},
+  [ComposeM] = {keys_compose_m, "latin"},
+  [ComposeMath] = {keys_compose_math, "latin"},
+  [ComposePunctuation] = {keys_compose_punctuation, "latin"},
+  [ComposeBracket] = {keys_compose_bracket, "latin"},
+
+  [Index] = {keys_index,"latin","index", false},
+};
+
+/* key layouts
+ *
+ * define keys like:
+ *
+ *  `{
+ *     "label",
+ *     "SHIFT_LABEL",
+ *     1,
+ *     [Code, Mod, Layout, EndRow, Last],
+ *     [KEY_CODE, Modifier],
+ *     [&layout]
+ *  },`
+ *
+ * - label: normal label for key
+ *
+ * - shift_label: label for key in shifted (uppercase) layout
+ *
+ * - width: column width of key
+ *
+ * - type: what kind of action this key peforms (emit keycode, toggle modifier,
+ *   switch layout, or end the layout)
+ *
+ * - code: key scancode or modifier name (see
+ *   `/usr/include/linux/input-event-codes.h` for scancode names, and
+ *   `keyboard.h` for modifiers)
+ *
+ * - layout: layout to switch to when key is pressed
+ */
+static struct key keys_full[] = {
+  {"Esc", "Esc", 1.25, Code, KEY_ESC, .scheme = 1},
+  {"F1", "F1", 1.0, Code, KEY_F1, .scheme = 1},
+  {"F2", "F2", 1.0, Code, KEY_F2, .scheme = 1},
+  {"F3", "F3", 1.0, Code, KEY_F3, .scheme = 1},
+  {"F4", "F4", 1.0, Code, KEY_F4, .scheme = 1},
+  {"F5", "F5", 1.0, Code, KEY_F5, .scheme = 1},
+  {"F6", "F6", 1.0, Code, KEY_F6, .scheme = 1},
+  {"F7", "F7", 1.0, Code, KEY_F7, .scheme = 1},
+  {"F8", "F8", 1.0, Code, KEY_F8, .scheme = 1},
+  {"F9", "F9", 1.0, Code, KEY_F9, .scheme = 1},
+  {"F10", "F10", 1.0, Code, KEY_F10, .scheme = 1},
+  {"F11", "F11", 1.0, Code, KEY_F11, .scheme = 1},
+  {"F12", "F12", 1.0, Code, KEY_F12, .scheme = 1},
+  {"Del", "Del", 1.25, Code, KEY_DELETE, .scheme = 1},
+  {"", "", 0.0, EndRow},
+
+  {"`", "~", 1.0, Code, KEY_GRAVE},
+  {"1", "!", 1.0, Code, KEY_1},
+  {"2", "@", 1.0, Code, KEY_2},
+  {"3", "#", 1.0, Code, KEY_3},
+  {"4", "$", 1.0, Code, KEY_4},
+  {"5", "%", 1.0, Code, KEY_5},
+  {"6", "^", 1.0, Code, KEY_6},
+  {"7", "&", 1.0, Code, KEY_7},
+  {"8", "*", 1.0, Code, KEY_8},
+  {"9", "(", 1.0, Code, KEY_9, &layouts[ComposeBracket]},
+  {"0", ")", 1.0, Code, KEY_0, &layouts[ComposeBracket]},
+  {"-", "_", 1.0, Code, KEY_MINUS, &layouts[ComposeBracket]},
+  {"=", "+", 1.0, Code, KEY_EQUAL, &layouts[ComposeBracket]},
+  {"⌫", "⌫", 1.5, Code, KEY_BACKSPACE, .scheme = 1},
+  {"", "", 0.0, EndRow},
+
+  {"Tab", "Tab", 1.5, Code, KEY_TAB, .scheme = 1},
+  {"q", "Q", 1.0, Code, KEY_Q},
+  {"w", "W", 1.0, Code, KEY_W, &layouts[ComposeW]},
+  {"e", "E", 1.0, Code, KEY_E, &layouts[ComposeE]},
+  {"r", "R", 1.0, Code, KEY_R, &layouts[ComposeR]},
+  {"t", "T", 1.0, Code, KEY_T, &layouts[ComposeT]},
+  {"y", "Y", 1.0, Code, KEY_Y, &layouts[ComposeY]},
+  {"u", "U", 1.0, Code, KEY_U, &layouts[ComposeU]},
+  {"i", "I", 1.0, Code, KEY_I, &layouts[ComposeI]},
+  {"o", "O", 1.0, Code, KEY_O, &layouts[ComposeO]},
+  {"p", "P", 1.0, Code, KEY_P, &layouts[ComposeP]},
+  {"[", "{", 1.0, Code, KEY_LEFTBRACE},
+  {"]", "}", 1.0, Code, KEY_RIGHTBRACE},
+  {"\\", "|", 1.0, Code, KEY_BACKSLASH},
+  {"", "", 0.0, EndRow},
+
+  {"Cmp", "Cmp", 1.0, Compose, .scheme = 1},
+  {"Caps", "Caps", 1.0, Mod, CapsLock, .scheme = 1},
+  {"a", "A", 1.0, Code, KEY_A, &layouts[ComposeA]},
+  {"s", "S", 1.0, Code, KEY_S, &layouts[ComposeS]},
+  {"d", "D", 1.0, Code, KEY_D, &layouts[ComposeD]},
+  {"f", "F", 1.0, Code, KEY_F, &layouts[ComposeF]},
+  {"g", "G", 1.0, Code, KEY_G, &layouts[ComposeG]},
+  {"h", "H", 1.0, Code, KEY_H, &layouts[ComposeH]},
+  {"j", "J", 1.0, Code, KEY_J, &layouts[ComposeJ]},
+  {"k", "K", 1.0, Code, KEY_K, &layouts[ComposeK]},
+  {"l", "L", 1.0, Code, KEY_L, &layouts[ComposeL]},
+  {";", ":", 1.0, Code, KEY_SEMICOLON},
+  {"'", "''", 1.0, Code, KEY_APOSTROPHE, &layouts[ComposeBracket]},
+  {"Enter", "Enter", 1.5, Code, KEY_ENTER, .scheme = 1},
+  {"", "", 0.0, EndRow},
+
+  {"⇧", "⇫", 2.5, Mod, Shift, .scheme = 1},
+  {"z", "Z", 1.0, Code, KEY_Z, &layouts[ComposeZ]},
+  {"x", "X", 1.0, Code, KEY_X, &layouts[ComposeX]},
+  {"c", "C", 1.0, Code, KEY_C, &layouts[ComposeC]},
+  {"v", "V", 1.0, Code, KEY_V, &layouts[ComposeV]},
+  {"b", "B", 1.0, Code, KEY_B, &layouts[ComposeB]},
+  {"n", "N", 1.0, Code, KEY_N, &layouts[ComposeN]},
+  {"m", "M", 1.0, Code, KEY_M, &layouts[ComposeM]},
+  {",", "<", 1.0, Code, KEY_COMMA, &layouts[ComposeMath]},
+  {".", ">", 1.0, Code, KEY_DOT, &layouts[ComposePunctuation]},
+  {"/", "?", 1.0, Code, KEY_SLASH},
+  {"↑", "↑", 1.0, Code, KEY_UP, .scheme = 1},
+  {"⇧", "⇫", 1.0, Mod, Shift, .scheme = 1},
+  {"", "", 0.0, EndRow},
+
+  {"⌨͕", "⌨͔", 1.5, NextLayer, .scheme = 1},
+  {"Ctr", "Ctr", 1.0, Mod, Ctrl, .scheme = 1},
+  {"Sup", "Sup", 1.0, Mod, Super, .scheme = 1},
+  {"Alt", "Alt", 1.0, Mod, Alt, .scheme = 1},
+  {"", "", 5.0, Code, KEY_SPACE},
+  {"AGr", "AGr", 1.0, Mod, AltGr, .scheme = 1},
+  {"Ctr", "Ctr", 1.0, Mod, Ctrl, .scheme = 1},
+  {"←", "←", 1.0, Code, KEY_LEFT, .scheme = 1},
+  {"↓", "↓", 1.0, Code, KEY_DOWN, .scheme = 1},
+  {"→", "→", 1.0, Code, KEY_RIGHT, .scheme = 1},
+  /* end of layout */
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_special[] = {
+  {"", "", 13.25, Pad},
+  {"Ins", "Ins", 1.25, Code, KEY_INSERT, .scheme = 1},
+  {"", "", 0.0, EndRow},
+
+  {"", "", 14.5, Pad},
+  {"", "", 0.0, EndRow},
+
+  {"", "", 14.5, Pad},
+  {"", "", 0.0, EndRow},
+
+  {"", "", 14.5, Pad},
+  {"", "", 0.0, EndRow},
+
+  {"⇧", "⇫", 2.5, Mod, Shift, .scheme = 1},
+  {"", "", 10.0, Pad},
+  {"PgUp", "PgUp", 1.0, Code, KEY_PAGEUP, .scheme = 1},
+  {"⇧", "⇫", 1.0, Mod, Shift, .scheme = 1},
+  {"", "", 0.0, EndRow},
+
+  {"⌨͕", "⌨͔", 0.75, NextLayer, .scheme = 1},
+  {"Abc", "Abc", 0.75, BackLayer, .scheme = 1},
+
+  {"Ctr", "Ctr", 1.0, Mod, Ctrl, .scheme = 1},
+  {"Sup", "Sup", 1.0, Mod, Super, .scheme = 1},
+  {"Alt", "Alt", 1.0, Mod, Alt, .scheme = 1},
+  {"", "", 5.0, Pad},
+  {"AGr", "AGr", 1.0, Mod, AltGr, .scheme = 1},
+  {"Ctr", "Ctr", 1.0, Mod, Ctrl, .scheme = 1},
+  {"Home", "Home", 1.0, Code, KEY_HOME, .scheme = 1},
+  {"PgDn", "PgDn", 1.0, Code, KEY_PAGEDOWN, .scheme = 1},
+  {"End", "End", 1.0, Code, KEY_END, .scheme = 1},
+  /* end of layout */
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_a[] = {
+  {"à", "À", 1.0, Copy, 0x00E0, 0, 0x00C0},
+  {"á", "Á", 1.0, Copy, 0x00E1, 0, 0x00C1},
+  {"â", "Â", 1.0, Copy, 0x00E2, 0, 0x00C2},
+  {"ã", "Ã", 1.0, Copy, 0x00E3, 0, 0x00C3},
+  {"ä", "Ä", 1.0, Copy, 0x00E4, 0, 0x00C4},
+  {"å", "Å", 1.0, Copy, 0x00E5, 0, 0x00C5},
+  {"æ", "Æ", 1.0, Copy, 0x00E7, 0, 0x00C6},
+  {"ā", "Ā", 1.0, Copy, 0x0101, 0, 0x0100},
+  {"ă", "Ă", 1.0, Copy, 0x0103, 0, 0x0102},
+  {"ą", "Ą", 1.0, Copy, 0x0105, 0, 0x0104},
+  {"", "", 0.0, EndRow},
+  {"α", "Α", 1.0, Copy, 0x03B1, 0, 0x0391},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_e[] = {
+  {"è", "È", 1.0, Copy, 0x00E8, 0, 0x00C8},
+  {"é", "É", 1.0, Copy, 0x00E9, 0, 0x00C9},
+  {"ê", "Ê", 1.0, Copy, 0x00EA, 0, 0x00CA},
+  {"ë", "Ë", 1.0, Copy, 0x00EB, 0, 0x00CB},
+  {"ē", "Ē", 1.0, Copy, 0x0113, 0, 0x0112},
+  {"ĕ", "Ĕ", 1.0, Copy, 0x0115, 0, 0x0114},
+  {"ė", "Ė", 1.0, Copy, 0x0117, 0, 0x0116},
+  {"ę", "Ę", 1.0, Copy, 0x0119, 0, 0x0118},
+  {"ě", "Ě", 1.0, Copy, 0x011B, 0, 0x011A},
+  {"", "", 1.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"ε", "Ε", 1.0, Copy, 0x03B5, 0, 0x0395},
+  {"ǝ", "Ə", 1.0, Copy, 0x0259, 0, 0x018F},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_y[] = {
+  {"ý", "Ý", 1.0, Copy, 0x00FD, 0, 0x00DD},
+  {"ÿ", "Ÿ", 1.0, Copy, 0x00FF, 0, 0x0178},
+  {"ŷ", "Ŷ", 1.0, Copy, 0x0177, 0, 0x0176},
+  {"", "", 7.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"υ", "Υ", 1.0, Copy, 0x03C5, 0, 0x03A5},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_u[] = {
+  {"ù", "Ù", 1.0, Copy, 0x00F9, 0, 0x00D9},
+  {"ú", "Ú", 1.0, Copy, 0x00FA, 0, 0x00DA},
+  {"û", "Û", 1.0, Copy, 0x00FB, 0, 0x00DB},
+  {"ü", "Ü", 1.0, Copy, 0x00FC, 0, 0x00DC},
+  {"ũ", "Ũ", 1.0, Copy, 0x0169, 0, 0x0168},
+  {"ū", "Ū", 1.0, Copy, 0x016B, 0, 0x016A},
+  {"ŭ", "Ŭ", 1.0, Copy, 0x016D, 0, 0x016C},
+  {"ů", "Ů", 1.0, Copy, 0x016F, 0, 0x016E},
+  {"ű", "Ű", 1.0, Copy, 0x0171, 0, 0x0170},
+  {"ų", "Ų", 1.0, Copy, 0x0173, 0, 0x0172},
+  {"", "", 0.0, EndRow},
+  {"υ", "Υ", 1.0, Copy, 0x03C5, 0, 0x03A5},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_o[] = {
+  {"ò", "Ò", 1.0, Copy, 0x00F2, 0, 0x00D2},
+  {"ó", "Ó", 1.0, Copy, 0x00F3, 0, 0x00D3},
+  {"ô", "Ô", 1.0, Copy, 0x00F4, 0, 0x00D4},
+  {"õ", "Õ", 1.0, Copy, 0x00F5, 0, 0x00D5},
+  {"ö", "Ö", 1.0, Copy, 0x00F6, 0, 0x00D6},
+  {"ø", "Ø", 1.0, Copy, 0x00F8, 0, 0x00D8},
+  {"ō", "Ō", 1.0, Copy, 0x014D, 0, 0x014C},
+  {"ŏ", "Ŏ", 1.0, Copy, 0x014F, 0, 0x014E},
+  {"ő", "Ő", 1.0, Copy, 0x0151, 0, 0x0150},
+  {"œ", "Œ", 1.0, Copy, 0x0153, 0, 0x0152},
+  {"", "", 0.0, EndRow},
+  {"ο", "Ο", 1.0, Copy, 0x03BF, 0, 0x039F},
+  {"ω", "Ο", 1.0, Copy, 0x03C9, 0, 0x03A9},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_i[] = {
+  {"ì", "Ì", 1.0, Copy, 0x00EC, 0, 0x00CC},
+  {"í", "Í", 1.0, Copy, 0x00ED, 0, 0x00CD},
+  {"î", "Î", 1.0, Copy, 0x00EE, 0, 0x00CE},
+  {"ï", "Ï", 1.0, Copy, 0x00EF, 0, 0x00CF},
+  {"ĩ", "Ĩ", 1.0, Copy, 0x0129, 0, 0x0128},
+  {"ī", "Ī", 1.0, Copy, 0x012B, 0, 0x012A},
+  {"ĭ", "Ĭ", 1.0, Copy, 0x012D, 0, 0x012C},
+  {"į", "Į", 1.0, Copy, 0x012F, 0, 0x012E},
+  {"ı", "I", 1.0, Copy, 0x0131, 0, 0x0049},
+  {"i", "İ", 1.0, Copy, 0x0069, 0, 0x0130},
+  {"", "", 0.0, EndRow},
+  {"ι", "Ι", 1.0, Copy, 0x03B9, 0, 0x0399},
+  {"η", "Η", 1.0, Copy, 0x03B7, 0, 0x0397},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_index[] = {
+  {"Full", "Full", 1.0, Layout, 0, &layouts[Full], .scheme = 1},
+  {"Special", "Special", 1.0, Layout, 0, &layouts[Special], .scheme = 1},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_w[] = {
+  {"ŵ", "Ŵ", 1.0, Copy, 0x0175, 0, 0x0174},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_r[] = {
+  {"ŕ", "Ŕ", 1.0, Copy, 0x0155, 0, 0x0154},
+  {"ŗ", "Ŗ", 1.0, Copy, 0x0157, 0, 0x0156},
+  {"ř", "Ř", 1.0, Copy, 0x0159, 0, 0x0158},
+  {"", "", 7.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"ρ", "Ρ", 1.0, Copy, 0x03C1, 0, 0x03A1},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_t[] = {
+  {"ț", "Ț", 1.0, Copy, 0x021B, 0, 0x021A},
+  {"ť", "Ť", 1.0, Copy, 0x0165, 0, 0x0164},
+  {"ŧ", "Ŧ", 1.0, Copy, 0x0167, 0, 0x0166},
+  {"þ", "Þ", 1.0, Copy, 0x00FE, 0, 0x00DE},
+  {"", "", 6.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"τ", "Τ", 1.0, Copy, 0x03C4, 0, 0x03A4},
+  {"θ", "Θ", 1.0, Copy, 0x03B8, 0, 0x0398},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_p[] = {
+  {"π", "Π", 1.0, Copy, 0x03C0, 0, 0x03A0},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_s[] = {
+  {"ś", "Ś", 1.0, Copy, 0x015B, 0, 0x015A},
+  {"ŝ", "Ŝ", 1.0, Copy, 0x015D, 0, 0x015C},
+  {"ş", "Ş", 1.0, Copy, 0x015F, 0, 0x015E},
+  {"š", "Š", 1.0, Copy, 0x0161, 0, 0x0160},
+  {"ß", "ẞ", 1.0, Copy, 0x00DF, 0, 0x1E9E},
+  {"", "", 5.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"σ", "Σ", 1.0, Copy, 0x03C3, 0, 0x03A3},
+  {"ς", "Σ", 1.0, Copy, 0x03C2, 0, 0x03A3},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_d[] = {
+  {"ð", "Ð", 1.0, Copy, 0x00F0, 0, 0x00D0},
+  {"ď", "Ď", 1.0, Copy, 0x010F, 0, 0x010E},
+  {"đ", "Đ", 1.0, Copy, 0x0111, 0, 0x0110},
+  {"", "", 7.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"δ", "Δ", 1.0, Copy, 0x03B4, 0, 0x0394},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_f[] = {
+  {"φ", "Φ", 1.0, Copy, 0x03C6, 0, 0x03A6},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_g[] = {
+  {"ĝ", "Ĝ", 1.0, Copy, 0x011D, 0, 0x011C},
+  {"ğ", "Ğ", 1.0, Copy, 0x011F, 0, 0x011E},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"γ", "Γ", 1.0, Copy, 0x03B3, 0, 0x0393},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_h[] = {
+  {"ĥ", "Ĥ", 1.0, Copy, 0x0125, 0, 0x0124},
+  {"ħ", "Ħ", 1.0, Copy, 0x0127, 0, 0x0126},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"η", "Η", 1.0, Copy, 0x03B7, 0, 0x0397},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_j[] = {
+  {"ĵ", "Ĵ", 1.0, Copy, 0x0135, 0, 0x0134},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 10.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_k[] = {
+  {"ķ", "Ķ", 1.0, Copy, 0x0137, 0, 0x0136},
+  {"ǩ", "Ǩ", 1.0, Copy, 0x01E9, 0, 0x01E8},
+  {"", "", 8.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"κ", "Κ", 1.0, Copy, 0x03BA, 0, 0x039A},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_l[] = {
+  {"ľ", "Ľ", 1.0, Copy, 0x013E, 0, 0x013D},
+  {"ŀ", "Ŀ", 1.0, Copy, 0x0140, 0, 0x013F},
+  {"ł", "Ł", 1.0, Copy, 0x0142, 0, 0x0141},
+  {"", "", 7.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"λ", "Λ", 1.0, Copy, 0x03BB, 0, 0x039B},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_z[] = {
+  {"ź", "Ź", 1.0, Copy, 0x017A, 0, 0x0179},
+  {"ż", "Ż", 1.0, Copy, 0x017C, 0, 0x017B},
+  {"ž", "Ž", 1.0, Copy, 0x017E, 0, 0x017D},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"ζ", "Ζ", 1.0, Copy, 0x03B6, 0, 0x0396},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_x[] = {
+  {"χ", "Χ", 1.0, Copy, 0x03C7, 0, 0x03A7},
+  {"ξ", "Ξ", 1.0, Copy, 0x03BE, 0, 0x039E},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_c[] = {
+  {"ç", "Ç", 1.0, Copy, 0x00E7, 0, 0x00C7},
+  {"ć", "Ć", 1.0, Copy, 0x0107, 0, 0x0106},
+  {"ĉ", "Ĉ", 1.0, Copy, 0x0109, 0, 0x0108},
+  {"ċ", "Ċ", 1.0, Copy, 0x010B, 0, 0x010A},
+  {"č", "Č", 1.0, Copy, 0x010D, 0, 0x010C},
+  {"", "", 5.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"χ", "Χ", 1.0, Copy, 0x03C7, 0, 0x03A7},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_v[] = {
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_b[] = {
+  {"β", "Β", 1.0, Copy, 0x03B2, 0, 0x0392},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_n[] = {
+  {"ñ", "Ñ", 1.0, Copy, 0x00F1, 0, 0x00D1},
+  {"ń", "Ń", 1.0, Copy, 0x0144, 0, 0x0143},
+  {"ņ", "Ņ", 1.0, Copy, 0x0146, 0, 0x0145},
+  {"ň", "Ň", 1.0, Copy, 0x0148, 0, 0x0147},
+  {"ŋ", "Ŋ", 1.0, Copy, 0x014B, 0, 0x014A},
+  {"", "", 5.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"ν", "Ν", 1.0, Copy, 0x03BD, 0, 0x039D},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_m[] = {
+  {"μ", "Μ", 1.0, Copy, 0x03BC, 0, 0x039C},
+  {"", "", 9.0, Pad},
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 8.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_math[] = {
+  {"", "", 0.0, EndRow},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"+", "+", 1, Code, KEY_EQUAL, 0, Shift},
+  {"/", "/", 1, Code, KEY_SLASH},
+  {"*", "*", 1, Code, KEY_8, 0, Shift},
+  {"-", "-", 1, Code, KEY_MINUS},
+  {"=", "=", 1, Code, KEY_EQUAL},
+  {"_", "_", 1, Code, KEY_MINUS, 0, Shift},
+  {"—", "—", 1, Copy, 0x2014, 0, 0x2014},
+  {"", "", 1.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_punctuation[] = {
+  {"", "", 0.0, EndRow},
+  {"", "", 4.5, Pad},
+  {".", ".", 1, Code, KEY_DOT},
+  {"…", "…", 1, Copy, 0x2026, 0, 0x2026},
+  {":", ":", 1, Code, KEY_SEMICOLON, 0, Shift},
+  {";", ";", 1, Code, KEY_SEMICOLON, 0},
+  {"⍽", "⍽", 1, Copy, 0x202F, 0, 0x00A0},
+  {"", "", 0.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"", "", 3, Pad},
+  {"!", "!", 1, Code, KEY_1, 0, Shift},
+  {"?", "?", 1, Code, KEY_DOT, 0, Shift},
+  {"·", "·", 1, Copy, 0x2027, 0, 0x2027},
+  {",", ",", 1, Code, KEY_COMMA},
+  {"", "", 1.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"", "", 9, Pad},
+  {"", "", 0.0, Last},
+};
+
+static struct key keys_compose_bracket[] = {
+  {"", "", 0, EndRow},
+  {"", "", 1.5, Pad},
+  {"{", "{", 1, Code, KEY_LEFTBRACE, 0, Shift},
+  {"}", "}", 1, Code, KEY_RIGHTBRACE, 0, Shift},
+  {"[", "[", 1, Code, KEY_LEFTBRACE},
+  {"]", "]", 1, Code, KEY_RIGHTBRACE},
+  {"", "", 4.5, Pad},
+  {"", "", 0, EndRow},
+  {"⇧", "⇫", 1.5, Mod, Shift, .scheme = 1},
+  {"<", "<", 1, Code, KEY_COMMA, 0, AltGr},
+  {">", ">", 1, Code, KEY_SLASH, 0, Shift},
+  {"`", "`", 1, Code, KEY_GRAVE},
+  {"\"", "\"", 1, Code, KEY_APOSTROPHE, 0, Shift},
+  {"'", "'", 1, Code, KEY_APOSTROPHE},
+  {"", "", 3.5, Pad},
+  {"", "", 0.0, EndRow},
+  {"Abc", "Abc", 1.0, BackLayer, .scheme = 1},
+  {"Ctr", "Ctr", 1.0, Mod, Ctrl, .scheme = 1},
+  {"", "", 8, Pad},
+  {"", "", 0.0, Last},
+};


### PR DESCRIPTION
Let me send the pull request (PR) via GitHub for better visibility in this context. I can also send this patch by `git send-email` if you would like me to do it.

This PR adds a desktop layout set. I took over the work on the https://github.com/jjsullivan5196/wvkbd/pull/67.

The layout set is aimed at desktop, laptop, and tablet devices with a larger touchscreen. The layout is the US-International English below, adding a compose key.
https://en.wikipedia.org/wiki/QWERTY#US-International

I also referred to the [Framework Laptop 12](https://frame.work/laptop12)'s International English layout about the Fn (Function) layer's layout.

<img width="615" height="469" alt="framework-laptop-12-international-english" src="https://github.com/user-attachments/assets/6998e257-5d6e-46f3-a074-fa6f1410e793" />

The layout set was created based on the layout set by the user nine7nine (Jordan Johnston) <https://github.com/nine7nine>.

## Screenshots

The screenshots are below. I took the screenshots on the [Sway window manager](https://swaywm.org/) on Fedora Linux 42 on Framework Laptop 12 (a 2-in-1 laptop with a touchscreen). You can download the original image files [here](https://drive.google.com/drive/folders/1xuy4-H4fsJaevShItrUpW_lI3oFK0mvT?usp=drive_link) on my Google Drive.

### Landscape

**Layout `Landscape` (`keys_landscape`)**
<img width="640" height="400" alt="wvkbd-desktop-landscape" src="https://github.com/user-attachments/assets/8d943f64-9e7d-4ba4-9458-c880384483f5" />

**Layout `LandscapeSpecial` (`keys_landscape_special`)**
<img width="640" height="400" alt="wvkbd-desktop-landscape-special" src="https://github.com/user-attachments/assets/721fc105-5463-48f0-a982-598e82e245fa" />

### Portrait

**Layout `Full` (`keys_full`)**
<img width="400" height="640" alt="wvkbd-desktop-portrait" src="https://github.com/user-attachments/assets/acc5792e-b06e-4000-8f96-3087bc09f828" />

**Layout `Special` (`keys_special`)**
<img width="400" height="640" alt="wvkbd-desktop-portrait-special" src="https://github.com/user-attachments/assets/b0408bf4-1880-4223-852b-c9f68b5e07ea" />

## Reply to the comments

@proycon's comment (https://github.com/jjsullivan5196/wvkbd/pull/67#issuecomment-2027782803):

> >  Just credit my part of it in the commit, and we are good!
> This was my first thought as well; I understand this
> comes from [@nine7nine](https://github.com/nine7nine)'s fork with additional improvements by [@FearlessSpiff](https://github.com/FearlessSpiff) on
top. Right now the commit history in this PR doesn't reflect this though.
...
> [@FearlessSpiff](https://github.com/FearlessSpiff): Could you rebase the PR so the original commits are as
> they were (carrying the proper Author for attribution)? And then yours
> on top of that? (you might still have them in your working tree)

I added @nine7nine's name as a credit in the commit message. I couldn't find @nine7nine's branch in the forked repository. So, this PR is based on https://github.com/jjsullivan5196/wvkbd/pull/67, and rebased on the latest master branch. And I modified and adjusted the code. 

> Some other comments:
>
> I didn't really notice the line is not straight, but I do notice the
> slight border on the left/right yes. I suppose it's a purely aestethic
> choice or does it have some functional reason too?

I adjusted each key's width with `0.25 * N`. I set each row's total width as 14.5 in each layout.

> * I see some of the keys were renamed, which is okay but care has to be
>   taken to do  it consistently for all layers in the desktop layout
>   then. Changing labels also makes it a bit harder to document keys clearly as
>   the README refers to Cmp for example, I'd suggest not renaming these
>   keys unless there's a good reason). I noticed:
>     * "Cmp" changed to "><"
>     * Sup changed to "<Arch logo>"; ideally I think we better keep a distro-neutral label
>       in wvkbd rather than an Arch/Debian/Gentoo/.. logo
>       (even though I too mostly use Arch, btw)

I fixed the above things.

> * though 99% percent of desktop users are probably on a landscape
>   layout, some 1% have a portrait monitor. The layout that opens
>   then is still the same as in wvkbd-mobintl. Is this by choice? I'd be inclined to
>   just use the same new landscape layout in portrait mode since the screen is probably
>   wide enough on desktop.

I fixed the above thing. Now, the landscape and portrait modes have the same layouts.

> * Perhaps an AltGr key would be useful on the default layer (right of spacebar)?
>   It would give alternative access to some special keys users may
>   already be used too (and as an alterntive for Cmp).

I fixed the above thing. I added the AltGr key.

> * Currently the keymaps and layouts for the other languages are still in
>   the code, but not really modified. If they're not used they should be
>   removed. Ideally though, a desktop layout for cyrillic etc would be
>   great (if anyone's up for it).

I removed unused keymaps and layouts for other languages, also some compose layouts (`ComposeCyr*`) to simplify the layout set. I wanted to show a simple example so that users can modify and extend the `layout.*.h` file easily.

I see some duplicated codes between `layout.mobintl.h` and `layout.deskintl.h`. Can we move the code related to the layouts `Compose*` into a header file, such as `layout_compose.h`, and the `layout.mobintl.h` and `layout.deskintl.h` load the `layout_compose.h`?

@justinlovinger's comment (https://github.com/jjsullivan5196/wvkbd/pull/67#issuecomment-2645300798):

> `<`, `>`, and `?` type the wrong symbols.

I still have no idea about how to fix this issue. Could you tell me how to fix it?

## Notes

I executed `make format`. However, after executing the command, I see many changes including the `keymap.mobintl.h` and `layout.mobintl.h`. So, I didn't apply the changes to `keymap.deskintl.h` and `layout.deskintl.h`. Because I think it's better to align the content between the `*.mobintl.h` and `*.deskintl.h`.

```
$ clang-format --version
clang-format version 20.1.8 (Fedora 20.1.8-3.fc42)

$ make format

$ git status
On branch wip/layout-desktop
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   config.def.h
	modified:   drw.c
	modified:   drw.h
	modified:   keyboard.c
	modified:   keyboard.h
	typechange: keymap.deskintl.h
	modified:   keymap.mobintl.h
	modified:   layout.deskintl.h
	modified:   layout.mobintl.h
	modified:   main.c
	modified:   os-compatibility.h
```

So, what do you think?
