### PR TITLE
Add flags to suppress key-press feedback

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -646,9 +646,12 @@ kbd_draw_key(struct kbd *kb, struct key *k, enum key_draw_type type)
         break;
     case Press:
         draw_inset(kb->surf, k->x, k->y, k->w, k->h, KBD_KEY_BORDER,
-                   scheme->high, scheme->rounding);
-        drw_draw_text(kb->surf, scheme->text_press, k->x, k->y, k->w, k->h,
-                  KBD_KEY_BORDER, label, scheme->font_description);
+                   kb->show_highlight ? scheme->high : scheme->fg,
+                   scheme->rounding);
+        drw_draw_text(kb->surf,
+                  kb->show_highlight ? scheme->text_press : scheme->text,
+                  k->x, k->y, k->w, k->h, KBD_KEY_BORDER, label,
+                  scheme->font_description);
         break;
     case Swipe:
         draw_over_inset(kb->surf, k->x, k->y, k->w, k->h, KBD_KEY_BORDER,
@@ -662,7 +665,7 @@ kbd_draw_key(struct kbd *kb, struct key *k, enum key_draw_type type)
     }
 
 
-    if (type == Press || type == Unpress) {
+    if (kb->show_popup && (type == Press || type == Unpress)) {
         kbd_clear_last_popup(kb);
 
         kb->last_popup_x = k->x;
@@ -673,9 +676,12 @@ kbd_draw_key(struct kbd *kb, struct key *k, enum key_draw_type type)
         drw_fill_rectangle(kb->popup_surf, scheme->bg, k->x,
                            kb->last_popup_y, k->w, k->h, scheme->rounding);
         draw_inset(kb->popup_surf, k->x, kb->last_popup_y, k->w, k->h,
-                   KBD_KEY_BORDER, scheme->high, scheme->rounding);
-        drw_draw_text(kb->popup_surf, scheme->text_press, k->x, kb->last_popup_y,
-                      k->w, k->h, KBD_KEY_BORDER, label,
+                   KBD_KEY_BORDER,
+                   kb->show_highlight ? scheme->high : scheme->fg,
+                   scheme->rounding);
+        drw_draw_text(kb->popup_surf,
+                      kb->show_highlight ? scheme->text_press : scheme->text,
+                      k->x, kb->last_popup_y, k->w, k->h, KBD_KEY_BORDER, label,
                       scheme->font_description);
     }
 }

--- a/keyboard.h
+++ b/keyboard.h
@@ -93,6 +93,8 @@ struct layout {
 
 struct kbd {
 	bool debug;
+	bool show_popup;
+	bool show_highlight;
 
 	struct layout *layout;
 	struct clr_scheme *schemes;

--- a/main.c
+++ b/main.c
@@ -603,6 +603,10 @@ usage(char *argv0)
     fprintf(stderr, "  -R [int]    - Rounding radius in pixels\n");
     fprintf(stderr, "  --fn [font] - Set font (e.g: DejaVu Sans 20)\n");
     fprintf(stderr, "  --hidden    - Start hidden (send SIGUSR2 to show)\n");
+    fprintf(stderr, "  --no-popup  - Disable the key-press popup\n");
+    fprintf(stderr, "  --no-highlight - Don't highlight a key while pressed\n");
+    fprintf(stderr, "  --no-feedback - Disable all key-press feedback "
+                    "(--no-popup and --no-highlight)\n");
     fprintf(
         stderr,
         "  --alpha [int]          - Set alpha value for all colors [0-255]\n");
@@ -812,6 +816,8 @@ main(int argc, char **argv)
     keyboard.preferred_scale = 1;
     keyboard.preferred_fractional_scale = 0;
     keyboard.exclusive = true;
+    keyboard.show_popup = true;
+    keyboard.show_highlight = true;
 
     uint8_t alpha = 0;
     bool alpha_defined = false;
@@ -971,6 +977,16 @@ main(int argc, char **argv)
         } else if ((!strcmp(argv[i], "-hidden")) ||
                    (!strcmp(argv[i], "--hidden"))) {
             hidden = true;
+        } else if ((!strcmp(argv[i], "-no-popup")) ||
+                   (!strcmp(argv[i], "--no-popup"))) {
+            keyboard.show_popup = false;
+        } else if ((!strcmp(argv[i], "-no-highlight")) ||
+                   (!strcmp(argv[i], "--no-highlight"))) {
+            keyboard.show_highlight = false;
+        } else if ((!strcmp(argv[i], "-no-feedback")) ||
+                   (!strcmp(argv[i], "--no-feedback"))) {
+            keyboard.show_popup = false;
+            keyboard.show_highlight = false;
         } else if ((!strcmp(argv[i], "-list-layers")) ||
                    (!strcmp(argv[i], "--list-layers"))) {
             list_layers();

--- a/wvkbd.1.scd
+++ b/wvkbd.1.scd
@@ -51,6 +51,18 @@ can be patched to add new features.
 *--hidden*
 	Start hidden (send SIGUSR2 to show).
 
+*--no-popup*
+	Disable the key-press popup (the magnified key shown above a key while
+	it is held). Useful for privacy, e.g. when typing on a lockscreen.
+
+*--no-highlight*
+	Don't highlight a key while it is pressed (draw it the same as an
+	unpressed key). Useful for privacy, e.g. when typing on a lockscreen.
+
+*--no-feedback*
+	Disable all visual key-press feedback; shorthand for *--no-popup* and
+	*--no-highlight* together.
+
 *--non-exclusive*
 	Allow keyboard to overlap existing windows, do not request an
 	exclusive zone from the compositor.


### PR DESCRIPTION
## Summary
Adds three flags to suppress wvkbd's visual key-press feedback:

| flag | effect |
|------|--------|
| `--no-popup` | disable the magnified key-press popup |
| `--no-highlight` | don't highlight the pressed key (draw it like an unpressed key; also de-highlights the popup when it is shown) |
| `--no-feedback` | shorthand for `--no-popup` + `--no-highlight` |

## Motivation
The press feedback reveals which key is being pressed. When wvkbd is used as an
on-screen keyboard on a **lockscreen**, that lets a shoulder-surfer read the
password being typed. These flags let privacy-sensitive setups turn it off.

The popup in particular **cannot** be hidden via colours (it draws the key
label), so a dedicated flag is the only way. The highlight is reachable via
`--press`, but `--no-highlight`/`--no-feedback` are offered as convenient single
switches and to de-highlight the popup consistently.

## Behaviour
- All feedback stays **enabled by default** — existing behaviour is unchanged.
- Implemented as `show_popup` / `show_highlight` on `struct kbd` (default true);
  `kbd_draw_key()` honours them for both the on-keyboard key and the popup.
- Documented in `usage()` and the man page.

## Relation to #123 
Needs/builds on the deskintl popup-colour fix (#<FIX>): on **deskintl** the
popup is empty until that lands, so the default/`--no-popup` behaviour is
easiest to evaluate with it merged. The flags themselves are independent and
sit on `master`.

## Test
- `make LAYOUT=mobintl` and `make LAYOUT=deskintl` build cleanly.
- `--no-popup` → no popup; `--no-highlight` → pressed key not highlighted;
  `--no-feedback` → neither. Default unchanged.

## Note on formatting
Diff kept minimal and matched to each file's existing indentation. I did not run
`make format` because the locally-available clang-format version reformats large
amounts of unrelated code; happy to apply a format pass with whatever
clang-format version CI uses.
